### PR TITLE
Improve UUID array SELECT query by using IN clause.

### DIFF
--- a/index.php
+++ b/index.php
@@ -410,10 +410,11 @@ function constructWhereWithUUIDs($uuidArray, $idColumn){
 	$whereStatement = NULL;
 
 	if (count($uuidArray) > 1) {
-		foreach ($uuidArray as $uuid) {
-			$whereStatement = $whereStatement.$idColumn." = UNHEX('".$uuid."') OR ";
-		}
-		$whereStatement = substr($whereStatement, 0, -4);
+		$whereStatement = $idColumn." IN (";
+        foreach ($uuidArray as $uuid) {
+            $whereStatement = $whereStatement."UNHEX('".$uuid."'),";
+        }
+        $whereStatement = substr($whereStatement, 0, -1).")";
 	} else if(count($uuidArray) == 1) {
 		$whereStatement = $idColumn." = UNHEX('".$uuidArray[0]."')";
 	}


### PR DESCRIPTION
This PR improves the SELECT query in constructWhereWithUUIDs($uuidArray, $idColumn) by utilizing the IN clause provided by MySQL instead of repeating if-field-equals statement in the WHERE clause.

This still doesn't fully improve the performance as mentioned in #70 but it does a little bit, caching should definitely be looked at.

P.S.: I'm not a PHP developer but I've tested this code and it works. I hope I'm not breaking any conventions with my one extra line. :P