### PR TITLE
feat: set correct utf8 settings for new installations

### DIFF
--- a/server/data/migrations/20180609143700-layouts.js
+++ b/server/data/migrations/20180609143700-layouts.js
@@ -4,16 +4,20 @@ exports.up = async function (db) {
   const { addComponents } = createLayoutHelper(db)
 
   await db.createTable('bm_web_page_layouts', {
-    id: { type: 'int', primaryKey: true, autoIncrement: true },
-    pathname: 'string',
-    device: 'string',
-    component: 'string',
-    x: 'int',
-    y: 'int',
-    w: 'int',
-    textAlign: 'string',
-    colour: 'string',
-    meta: 'longtext'
+    columns: {
+      id: { type: 'int', primaryKey: true, autoIncrement: true },
+      pathname: 'string',
+      device: 'string',
+      component: 'string',
+      x: 'int',
+      y: 'int',
+      w: 'int',
+      textAlign: 'string',
+      colour: 'string',
+      meta: 'longtext'
+    },
+    charset: 'utf8mb4',
+    collate: 'utf8mb4_unicode_ci'
   })
   await db.addIndex('bm_web_page_layouts', 'bm_web_page_layouts_pathname_idx', ['pathname'])
 

--- a/server/data/migrations/20211017122549-appeals.js
+++ b/server/data/migrations/20211017122549-appeals.js
@@ -2,8 +2,12 @@ const aclHelper = require('./lib/acl')
 
 exports.up = async function (db) {
   await db.createTable('bm_web_appeal_states', {
-    id: { type: 'int', notNull: true, primaryKey: true, autoIncrement: true },
-    name: { type: 'string', notNull: true }
+    columns: {
+      id: { type: 'int', notNull: true, primaryKey: true, autoIncrement: true },
+      name: { type: 'string', notNull: true }
+    },
+    charset: 'utf8mb4',
+    collate: 'utf8mb4_unicode_ci'
   })
   await db.createTable('bm_web_appeals', {
     columns: {
@@ -48,7 +52,8 @@ exports.up = async function (db) {
       updated: { type: 'int', length: 10, notNull: true },
       reason: { type: 'text', notNull: true }
     },
-    charset: 'utf8'
+    charset: 'utf8mb4',
+    collate: 'utf8mb4_unicode_ci'
   })
 
   await db.addIndex('bm_web_appeals', 'bm_web_appeals_server_idx', ['server_id'])
@@ -104,7 +109,8 @@ exports.up = async function (db) {
       created: { type: 'int', length: 10, notNull: true },
       updated: { type: 'int', length: 10, notNull: true }
     },
-    charset: 'utf8'
+    charset: 'utf8mb4',
+    collate: 'utf8mb4_unicode_ci'
   })
 
   const { addResource, addPermission, attachPermission } = aclHelper(db)

--- a/server/data/migrations/sqls/20180122081331-acls-up.sql
+++ b/server/data/migrations/sqls/20180122081331-acls-up.sql
@@ -10,14 +10,14 @@ CREATE TABLE `bm_web_servers` (
   `tables` text NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `bm_web_servers_name_unique` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_web_roles` (
   `role_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(30) NOT NULL,
   `parent_role_id` INT UNSIGNED NULL,
   PRIMARY KEY (`role_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_web_player_roles` (
   `player_id` BINARY(16) NOT NULL,
@@ -26,7 +26,7 @@ CREATE TABLE `bm_web_player_roles` (
   KEY bm_web_player_roles_player_id (`player_id`),
   KEY bm_web_player_roles_role_id (`role_id`),
   CONSTRAINT `bm_web_player_roles_role_id_fk` FOREIGN KEY (`role_id`) REFERENCES `bm_web_roles` (`role_id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_web_player_server_roles` (
   `player_id` BINARY(16) NOT NULL,
@@ -38,14 +38,14 @@ CREATE TABLE `bm_web_player_server_roles` (
   KEY bm_web_player_server_roles_server_id (`server_id`),
   CONSTRAINT `bm_web_player_server_roles_role_id_fk` FOREIGN KEY (`role_id`) REFERENCES `bm_web_roles` (`role_id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `bm_web_player_server_roles_server_id_fk` FOREIGN KEY (`server_id`) REFERENCES `bm_web_servers` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_web_resources` (
   `resource_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   PRIMARY KEY (`resource_id`),
   UNIQUE KEY `bm_web_resources_name_unique` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_web_resource_permissions` (
   `permission_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -55,7 +55,7 @@ CREATE TABLE `bm_web_resource_permissions` (
   PRIMARY KEY (`permission_id`),
   KEY `bm_web_resource_permissions_resource_id_index` (`resource_id`),
   CONSTRAINT `bm_web_resource_permissions_resource_id_fk` FOREIGN KEY (`resource_id`) REFERENCES `bm_web_resources` (`resource_id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_web_role_resources` (
   `role_id` INT UNSIGNED NOT NULL,
@@ -67,7 +67,7 @@ CREATE TABLE `bm_web_role_resources` (
   KEY `bm_web_group_resources_group_id_resource_id_index` (`role_id`,`resource_id`),
   CONSTRAINT `bm_web_role_resources_resource_id_fk` FOREIGN KEY (`resource_id`) REFERENCES `bm_web_resources` (`resource_id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `bm_web_role_resources_role_id_fk` FOREIGN KEY (`role_id`) REFERENCES `bm_web_roles` (`role_id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_web_users` (
   `player_id` binary(16) NOT NULL,
@@ -75,4 +75,4 @@ CREATE TABLE `bm_web_users` (
   `password` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`player_id`),
   KEY `bm_web_users_email_index` (`email`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/server/test/lib/setup.js
+++ b/server/test/lib/setup.js
@@ -26,7 +26,7 @@ module.exports = async (disableTestMigrations) => { // eslint-disable-line max-s
     })
   let dbPool = await setupPool(dbConfig)
 
-  await dbPool.raw(`CREATE DATABASE ${dbName}`)
+  await dbPool.raw(`CREATE DATABASE ${dbName} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`)
   await dbPool.destroy()
 
   dbConfig.database = dbName

--- a/server/test/migrations/sqls/20180208130239-bm-tables-up.sql
+++ b/server/test/migrations/sqls/20180208130239-bm-tables-up.sql
@@ -11,7 +11,7 @@ CREATE TABLE `bm_ip_ban_records` (
   `silent` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `bm_ip_ban_records_created_idx` (`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_ip_bans` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -26,7 +26,7 @@ CREATE TABLE `bm_ip_bans` (
   KEY `bm_ip_bans_created_idx` (`created`),
   KEY `bm_ip_bans_expires_idx` (`expires`),
   KEY `bm_ip_bans_updated_idx` (`updated`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_ip_mute_records` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -43,7 +43,7 @@ CREATE TABLE `bm_ip_mute_records` (
   PRIMARY KEY (`id`),
   KEY `bm_ip_mute_records_created_idx` (`created`),
   KEY `bm_ip_mute_records_soft_idx` (`soft`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_ip_mutes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -60,7 +60,7 @@ CREATE TABLE `bm_ip_mutes` (
   KEY `bm_ip_mutes_soft_idx` (`soft`),
   KEY `bm_ip_mutes_created_idx` (`created`),
   KEY `bm_ip_mutes_expires_idx` (`expires`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_ip_range_ban_records` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -78,7 +78,7 @@ CREATE TABLE `bm_ip_range_ban_records` (
   KEY `bm_ip_range_ban_records_created_idx` (`created`),
   KEY `bm_ip_range_ban_records_toIp_idx` (`toIp`),
   KEY `bm_ip_range_ban_records_fromIp_idx` (`fromIp`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_ip_range_bans` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -94,7 +94,7 @@ CREATE TABLE `bm_ip_range_bans` (
   KEY `bm_ip_range_bans_expires_idx` (`expires`),
   KEY `bm_ip_range_bans_created_idx` (`created`),
   KEY `bm_ip_range_bans_updated_idx` (`updated`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_name_ban_records` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -109,7 +109,7 @@ CREATE TABLE `bm_name_ban_records` (
   `silent` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `bm_name_ban_records_created_idx` (`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_name_bans` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -124,7 +124,7 @@ CREATE TABLE `bm_name_bans` (
   KEY `bm_name_bans_updated_idx` (`updated`),
   KEY `bm_name_bans_created_idx` (`created`),
   KEY `bm_name_bans_expires_idx` (`expires`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_player_ban_records` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -139,7 +139,7 @@ CREATE TABLE `bm_player_ban_records` (
   `silent` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `bm_player_ban_records_created_idx` (`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_player_bans` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -155,7 +155,7 @@ CREATE TABLE `bm_player_bans` (
   KEY `bm_player_bans_created_idx` (`created`),
   KEY `bm_player_bans_expires_idx` (`expires`),
   KEY `bm_player_bans_updated_idx` (`updated`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_player_history` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -167,7 +167,7 @@ CREATE TABLE `bm_player_history` (
   KEY `bm_player_history_ip_idx` (`ip`),
   KEY `bm_player_history_leave_idx` (`leave`),
   KEY `bm_player_history_join_idx` (`join`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_player_kicks` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -177,7 +177,7 @@ CREATE TABLE `bm_player_kicks` (
   `created` int(10) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `bm_player_kicks_created_idx` (`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_player_mute_records` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -194,7 +194,7 @@ CREATE TABLE `bm_player_mute_records` (
   PRIMARY KEY (`id`),
   KEY `bm_player_mute_records_soft_idx` (`soft`),
   KEY `bm_player_mute_records_created_idx` (`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_player_mutes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -212,7 +212,7 @@ CREATE TABLE `bm_player_mutes` (
   KEY `bm_player_mutes_soft_idx` (`soft`),
   KEY `bm_player_mutes_updated_idx` (`updated`),
   KEY `bm_player_mutes_created_idx` (`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_player_notes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -224,7 +224,7 @@ CREATE TABLE `bm_player_notes` (
   KEY `bm_player_notes_created_idx` (`created`),
   KEY `bm_player_notes_actor_idx` (`actor_id`),
   KEY `bm_player_notes_player_idx` (`player_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_player_pins` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -235,7 +235,7 @@ CREATE TABLE `bm_player_pins` (
   KEY `bm_player_pins_player_idx` (`player_id`),
   KEY `bm_player_pins_pin_idx` (`player_id`,`pin`),
   KEY `bm_player_pins_expires_idx` (`expires`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_player_report_commands` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -251,7 +251,7 @@ CREATE TABLE `bm_player_report_commands` (
   KEY `bm_player_report_commands_command_idx` (`command`),
   KEY `bm_player_report_commands_report_idx` (`report_id`),
   KEY `bm_player_report_commands_created_idx` (`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_player_report_comments` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -265,7 +265,7 @@ CREATE TABLE `bm_player_report_comments` (
   KEY `bm_player_report_comments_report_idx` (`report_id`),
   KEY `bm_player_report_comments_actor_idx` (`actor_id`),
   KEY `bm_player_report_comments_created_idx` (`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_player_report_locations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -281,13 +281,13 @@ CREATE TABLE `bm_player_report_locations` (
   KEY `bm_player_report_locations_player_idx` (`player_id`),
   KEY `bm_player_report_locations_world_idx` (`world`),
   KEY `bm_player_report_locations_report_idx` (`report_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_player_report_states` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 INSERT INTO `bm_player_report_states` (`id`, `name`) VALUES
   (1, 'Open'),
@@ -311,7 +311,7 @@ CREATE TABLE `bm_player_reports` (
   KEY `bm_player_reports_assignee_idx` (`assignee_id`),
   KEY `bm_player_reports_created_idx` (`created`),
   KEY `bm_player_reports_updated_idx` (`updated`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_player_warnings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -328,7 +328,7 @@ CREATE TABLE `bm_player_warnings` (
   KEY `bm_player_warnings_points_idx` (`points`),
   KEY `bm_player_warnings_created_idx` (`created`),
   KEY `bm_player_warnings_player_idx` (`player_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_players` (
   `id` binary(16) NOT NULL,
@@ -338,7 +338,7 @@ CREATE TABLE `bm_players` (
   PRIMARY KEY (`id`),
   KEY `bm_players_ip_idx` (`ip`),
   KEY `bm_players_name_idx` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_report_logs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -347,7 +347,7 @@ CREATE TABLE `bm_report_logs` (
   PRIMARY KEY (`id`),
   KEY `bm_report_logs_log_idx` (`log_id`),
   KEY `bm_report_logs_report_idx` (`report_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_rollbacks` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -359,7 +359,7 @@ CREATE TABLE `bm_rollbacks` (
   PRIMARY KEY (`id`),
   KEY `bm_rollbacks_created_idx` (`created`),
   KEY `bm_rollbacks_expires_idx` (`expires`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `bm_server_logs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -367,4 +367,4 @@ CREATE TABLE `bm_server_logs` (
   `created` int(10) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `bm_server_logs_created_idx` (`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
Currently blocked by https://github.com/db-migrate/mysql/issues/40