### PR TITLE
Fix how `Client-side Exception Occurred` gets thrown in some cases

### DIFF
--- a/components/admin/servers/PlayerActivity.js
+++ b/components/admin/servers/PlayerActivity.js
@@ -129,7 +129,7 @@ const ActivityRow = ({ row, index }) => {
             </span>
           </div>
           <div className='pt-2'>
-            {message.reduce((prev, curr) => [prev, ' ', curr])}
+            {message.length > 0 ? message.reduce((prev, curr) => [prev, ' ', curr]) : ''}
           </div>
           <div>
             <TimeFromNow timestamp={row.created} />


### PR DESCRIPTION
For some reason, the `message` array is empty on some punishments, and thus the array cannot be reduced. This throws a NextJS error that covers the whole page (https://nextjs.org/docs/messages/client-side-exception-occurred)

The modification applied checks whether the array is empty or no first before reducing it.