### PR TITLE
feat: add internationalization (i18n) support (#164)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,77 @@ In order for us to help you please check that you've completed the following ste
 * Develop in a topic branch, not master (e.g. `feature/new-view`)
 * Write a convincing description of your PR and why we should land it
 * If you write JavaScript, make sure you follow https://standardjs.com/
+
+## Localisation
+
+The UI uses [`next-intl`](https://next-intl.dev/) for client-side translations. Translation catalogues live in [`messages/`](messages/) and the locale registry / negotiation logic lives in [`server/data/locales.js`](server/data/locales.js) (re-exported by [`utils/locale.js`](utils/locale.js) for client code).
+
+### Authoring rules
+
+* Always introduce new user-facing text via `useTranslations(...)` (or `t.rich(...)` when the message contains markup or interpolated React elements). Never hard-code English strings in components.
+* Group keys by feature area: `common.*`, `nav.*`, `forms.*`, `pages.<page>.*`, `errors.*`, `widgets.*`, `notifications.*`, `components.*`.
+* Use ICU MessageFormat for plurals/interpolation: `"Removed {count, plural, one {# item} other {# items}}"`.
+* Keep `messages/en.json` as the canonical source of truth. Every other locale must mirror its key structure exactly.
+
+### Adding a string
+
+1. Add the key + English copy to `messages/en.json`.
+2. Add a translation under the same key in every other locale file (`messages/de.json`, etc.). If a translation is unavailable at submission time, copy the English value as a placeholder so the key still resolves.
+3. Reference the key from a component:
+   ```js
+   import { useTranslations } from 'next-intl'
+
+   const t = useTranslations('pages.login')
+   return <h1>{t('title')}</h1>
+   ```
+
+### Adding a new locale
+
+1. Add the locale code to `SUPPORTED_LOCALES` in `server/data/locales.js`.
+2. Extend `LOCALE_CONFIG` in `utils/locale.js` with `label` (native name shown in the switcher), `htmlLang`, `openGraphLocale`, `dateFormat`, and `dateFnsLocale` (must match a [`date-fns` locale module](https://date-fns.org/v4.1.0/docs/I18n)).
+3. Add the locale entry to `dateFnsLocaleLoaders` in `utils/format-distance.js` so dynamic imports work.
+4. Create `messages/<locale>.json` with a 1:1 copy of `messages/en.json`, then translate.
+5. Run `npm run build` and `npm run test` to verify the locale loads and tests pass.
+
+The `LanguageSwitcher` component automatically picks up new locales from `SUPPORTED_LOCALES` and renders them using the `label` from `LOCALE_CONFIG`.
+
+### Server-side error messages
+
+Errors thrown from GraphQL resolvers, GraphQL directives, REST routes, and webhook handlers are translated client-side via stable error codes — **not** by translating the server's English text.
+
+* Always pass an error code as the second argument to `ExposedError`:
+  ```js
+  throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
+  ```
+* For dynamic content (e.g. plurals, names), pass a `meta` object as the third argument:
+  ```js
+  throw new ExposedError('This password isn\'t safe…', 'PASSWORD_COMPROMISED', { count: 5 })
+  ```
+* In Koa REST routes, call `ctx.throw(status, message, { code: 'STABLE_CODE', meta: {...} })` so the JSON body exposes `code` and `meta`. The `code` and `meta` properties are surfaced by the error middleware in [`server/app.js`](server/app.js).
+* Add a corresponding key to `messages/<locale>.json` under `errors.<CODE>` for every supported locale. Use ICU placeholders matching the `meta` keys.
+* The client UI (`components/ErrorMessages.js`/`utils/locale.js#translateGraphqlError` for GraphQL, `utils/locale.js#translateRestError` for REST) looks up the code and falls back to the server's message if no translation exists.
+* `BAD_USER_INPUT` errors (raised by `graphql-constraint-directive`) are intentionally **not** assigned an `appCode`, so the constraint message is shown verbatim. See the out-of-scope list below.
+
+> **Compatibility note**: `ExposedError` now defaults `code` to `'UNKNOWN'` (and `extensions.appCode` to `'UNKNOWN'`) when no second argument is supplied. Previously this field was `undefined`. Any downstream consumer that checks `if (!err.code)` should be updated to check for the literal string `'UNKNOWN'` instead. New call-sites must always pass an explicit, stable code.
+
+### Out-of-scope (explicitly NOT translated)
+
+The following surfaces are intentionally left in English to keep the scope manageable:
+
+* The setup/installer SPA under `server/setup/static/` (run-once flow).
+* CLI command output (`cli/commands/**`, `cli/utils/**`).
+* `graphql-constraint-directive` validation messages.
+* User-generated content (player names, ban reasons, appeal/report comments, custom roles, server names, document content).
+* Server logs and Pino output (`logger.*` calls).
+
+If you want to localise any of these, please open an issue first to discuss scope.
+
+### Manual verification
+
+Before submitting a PR that touches localisation:
+
+1. Toggle the language switcher in the top-right and confirm the page re-renders in the chosen language.
+2. Reload the page and confirm the choice persisted via the `bm_locale` cookie.
+3. If you're logged in, confirm `setLocale` ran and the preference survives a logout/login cycle.
+4. Check that `<html lang="…">` updates to match (DevTools → Elements panel).
+5. Trigger a known server error (e.g. submit invalid login) and verify the message renders in the active locale.

--- a/README.md
+++ b/README.md
@@ -218,9 +218,22 @@ npm run test
 npm run cypress
 ```
 
+## Localisation
+
+The UI is localised with [`next-intl`](https://next-intl.dev/). Currently shipping languages: **English (`en`)** and **German (`de`)**.
+
+For details on adding a new language, translating new strings, or wiring up server-side error codes, see [`CONTRIBUTING.md`](CONTRIBUTING.md#localisation).
+
+Locale resolution order (highest priority first):
+
+1. Authenticated user's stored preference (`bm_web_users.locale`)
+2. `bm_locale` cookie (set by the in-app language switcher)
+3. `Accept-Language` HTTP header
+4. Fallback to `en`
+
 ## Contributing
 
-If you'd like to contribute, please fork the repository and use a feature branch. Pull requests are warmly welcome.
+If you'd like to contribute, please fork the repository and use a feature branch. Pull requests are warmly welcome. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for guidelines on translations, error codes, and other development conventions.
 
 ## Help / Bug / Feature Request
 

--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -1,9 +1,16 @@
 import { forwardRef } from 'react'
 import Datetime from '@nateradebaugh/react-datetime'
+import { useLocale } from 'next-intl'
 import clsx from 'clsx'
+import { LOCALE_CONFIG, DEFAULT_LOCALE } from '../utils/locale'
+import { useDateFnsLocale } from '../utils/format-distance'
 
 // eslint-disable-next-line react/display-name
-const DateTimePicker = forwardRef(({ className = '', inputClassName = '', error = false, disabled = false, icon = null, iconPosition = 'left', ...rest }, ref) => {
+const DateTimePicker = forwardRef(({ className = '', inputClassName = '', error = false, disabled = false, icon = null, iconPosition = 'left', dateFormat, ...rest }, ref) => {
+  const locale = useLocale()
+  const dateFnsLocale = useDateFnsLocale()
+  const localeConfig = LOCALE_CONFIG[locale] || LOCALE_CONFIG[DEFAULT_LOCALE]
+  const resolvedDateFormat = dateFormat || localeConfig.dateFormat
   const inputClass = clsx(`
     flex-1
     appearance-none
@@ -46,7 +53,7 @@ const DateTimePicker = forwardRef(({ className = '', inputClassName = '', error 
         <span className='rounded-l-3xl inline-flex items-center px-3 bg-primary-900 text-gray-400 text-lg'>
           {icon}
         </span>}
-      <Datetime ref={ref} dateFormat='dd/MM/yyyy' className={inputClass} {...rest} />
+      <Datetime ref={ref} dateFormat={resolvedDateFormat} locale={dateFnsLocale || undefined} className={inputClass} {...rest} />
     </div>
   )
 })

--- a/components/DefaultLayout.js
+++ b/components/DefaultLayout.js
@@ -2,10 +2,12 @@ import { useEffect, useMemo } from 'react'
 import Head from 'next/head'
 import { NextSeo } from 'next-seo'
 import Favicon from 'react-favicon'
+import { useTranslations } from 'next-intl'
 import { MdLogin } from 'react-icons/md'
 import Footer from './Footer'
 import Nav from './Nav'
 import SessionNavProfile from './SessionNavProfile'
+import LanguageSwitcher from './LanguageSwitcher'
 import PlayerSelector from './admin/PlayerSelector'
 import { useApi, useUser } from '../utils'
 import { useRouter, withRouter } from 'next/router'
@@ -17,20 +19,29 @@ const query = `query unreadNotificationCount {
   unreadNotificationCount
 }`
 
-const LoggedOutNav = () => (
-  <div className='hidden md:flex gap-4'>
-    <Link href='/login' passHref>
-      <Button className='text-sm'>
-        <MdLogin className='mr-2' /> Login
-      </Button>
-    </Link>
-  </div>
-)
+const langButtonClassName = 'bg-primary-900 !rounded-lg p-2 transform transition duration-300 hover:scale-110 hover:bg-primary-900 w-12 h-12 items-center'
+
+const LoggedOutNav = () => {
+  const t = useTranslations('nav')
+
+  return (
+    <div className='hidden md:flex gap-4 items-center'>
+      <LanguageSwitcher buttonClassName={langButtonClassName} />
+      <Link href='/login' passHref>
+        <Button className='text-sm'>
+          <MdLogin className='mr-2' /> {t('login')}
+        </Button>
+      </Link>
+    </div>
+  )
+}
 
 function DefaultLayout ({ title = 'Default Title', children, description, loading }) {
   const { user } = useUser()
   const { data } = useApi({ query: user?.id ? query : null }, { refreshInterval: 10000, refreshWhenHidden: true })
   const router = useRouter()
+  const tForms = useTranslations('forms')
+  const tNav = useTranslations('nav')
 
   useEffect(() => {
     if (data) {
@@ -59,11 +70,11 @@ function DefaultLayout ({ title = 'Default Title', children, description, loadin
       <PlayerSelector
         multiple={false}
         onChange={(id) => id ? router.push(`/player/${id}`) : undefined}
-        placeholder='Search player'
+        placeholder={tForms('playerSelectorPlaceholder')}
       />
     </div>]
   const right = useMemo(() => user?.id ? [<SessionNavProfile key='session-nav-profile' user={user} unreadNotificationCount={data?.unreadNotificationCount} />] : [<LoggedOutNav key='nav-logged-out' />], [user, data])
-  const mobileItems = useMemo(() => !user?.id ? [{ name: 'Login', href: '/login' }, { name: 'Create Appeal', href: '/appeal' }] : [], [user])
+  const mobileItems = useMemo(() => !user?.id ? [{ name: tNav('login'), href: '/login' }, { name: tNav('createAppeal'), href: '/appeal' }] : [], [user, tNav])
 
   return (
     <>

--- a/components/ErrorMessages.js
+++ b/components/ErrorMessages.js
@@ -1,6 +1,8 @@
 import { forwardRef } from 'react'
+import { useTranslations } from 'next-intl'
 import Message from './Message'
 import { uniqBy } from 'lodash-es'
+import { translateGraphqlError } from '../utils/locale'
 
 // eslint-disable-next-line react/display-name
 const ErrorMessages = forwardRef(({
@@ -10,19 +12,21 @@ const ErrorMessages = forwardRef(({
   parseError,
   errors
 }, ref) => {
+  const t = useTranslations()
+
   return (
     <>
       {error && (
         <Message ref={ref} error>
-          <Message.Header>Error</Message.Header>
+          <Message.Header>{t('errors.header')}</Message.Header>
           <Message.List data-cy='errors'>
-            <Message.Item>{error.message}</Message.Item>
+            <Message.Item>{translateGraphqlError(t, error)}</Message.Item>
           </Message.List>
         </Message>
       )}
       {fetchError && (
         <Message ref={ref} error>
-          <Message.Header>Fetch Error</Message.Header>
+          <Message.Header>{t('errors.fetchHeader')}</Message.Header>
           <Message.List>
             <Message.Item>{fetchError}</Message.Item>
           </Message.List>
@@ -30,13 +34,13 @@ const ErrorMessages = forwardRef(({
       )}
       {httpError && (
         <Message ref={ref} error>
-          <Message.Header>HTTP error: {httpError.status}</Message.Header>
+          <Message.Header>{t('errors.httpHeader', { status: httpError.status })}</Message.Header>
           {httpError.statusText && <Message.List><Message.Item>{httpError.statusText}</Message.Item></Message.List>}
         </Message>
       )}
       {parseError && (
         <Message ref={ref} error>
-          <Message.Header>Parse Error</Message.Header>
+          <Message.Header>{t('errors.header')}</Message.Header>
           <Message.List>
             <Message.Item>{parseError}</Message.Item>
           </Message.List>
@@ -44,10 +48,10 @@ const ErrorMessages = forwardRef(({
       )}
       {errors && (
         <Message ref={ref} error>
-          <Message.Header>Error</Message.Header>
+          <Message.Header>{t('errors.header')}</Message.Header>
           <Message.List data-cy='errors'>
-            {uniqBy(errors, 'message').map(({ message }, index) => (
-              <Message.Item key={index}>{message}</Message.Item>
+            {uniqBy(errors, 'message').map((err, index) => (
+              <Message.Item key={index}>{translateGraphqlError(t, err)}</Message.Item>
             ))}
           </Message.List>
         </Message>

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,5 +1,7 @@
 import Image from 'next/image'
+import { useTranslations } from 'next-intl'
 import { useApi } from '../utils'
+import LanguageSwitcher from './LanguageSwitcher'
 
 const query = `
   query settings {
@@ -10,19 +12,22 @@ const query = `
   }`
 
 export default function Footer () {
+  const t = useTranslations('footer')
+  const tCommon = useTranslations('common')
   const { data } = useApi({ query }, {
     revalidateIfStale: false,
     revalidateOnFocus: false,
     revalidateOnReconnect: false
   })
   const currentYear = new Date().getFullYear()
+  const fallbackName = `${t('powered')} ${tCommon('siteName')}`
 
   return (
     <footer className='text-gray-300 bg-primary-900'>
-      <div className='container px-5 py-8 mx-auto flex items-center sm:flex-row flex-col'>
+      <div className='container px-5 py-8 mx-auto flex items-center sm:flex-row flex-col gap-2'>
         <a className='flex title-font font-medium items-center md:justify-start justify-center'>
-          <Image src={(process.env.BASE_PATH || '') + '/images/banmanager-icon.png'} alt='Logo' width='35' height='35' />
-          <span className='ml-3 text-xl'>{data?.settings?.serverFooterName || 'Powered by BanManager'}</span>
+          <Image src={(process.env.BASE_PATH || '') + '/images/banmanager-icon.png'} alt={tCommon('siteName')} width='35' height='35' />
+          <span className='ml-3 text-xl'>{data?.settings?.serverFooterName || fallbackName}</span>
         </a>
         <p className='text-sm  sm:ml-4 sm:pl-4 sm:border-l-2 sm:border-gray-400 sm:py-2 sm:mt-0 mt-4'>
           &copy; {currentYear}
@@ -30,6 +35,9 @@ export default function Footer () {
         <p className='text-sm sm:pl-4 sm:py-2 sm:mt-0 mt-4'>
           {data?.settings?.additionalFooterText}
         </p>
+        <div className='sm:ml-auto'>
+          <LanguageSwitcher buttonClassName='!bg-primary-800 hover:!bg-primary-700 text-sm px-3 py-2' variant='inline' />
+        </div>
       </div>
     </footer>
   )

--- a/components/LanguageSwitcher.js
+++ b/components/LanguageSwitcher.js
@@ -1,0 +1,107 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
+import { mutate } from 'swr'
+import { MdLanguage } from 'react-icons/md'
+import Dropdown from './Dropdown'
+import Button from './Button'
+import { useUser } from '../utils'
+import {
+  LOCALE_CONFIG,
+  SUPPORTED_LOCALES,
+  isSupportedLocale,
+  useResolvedLocale,
+  writeLocaleCookie
+} from '../utils/locale'
+
+const setLocaleMutation = `
+  mutation setLocale($locale: String!) {
+    setLocale(locale: $locale) {
+      id
+      locale
+    }
+  }
+`
+
+export default function LanguageSwitcher ({ buttonClassName = '', variant = 'icon' }) {
+  const t = useTranslations('widgets.languageSwitcher')
+  const router = useRouter()
+  const { user } = useUser()
+  const { locale } = useResolvedLocale()
+  const [updating, setUpdating] = useState(false)
+
+  const persistRemoteLocale = async (next) => {
+    const response = await fetch((process.env.BASE_PATH || '') + '/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        query: setLocaleMutation,
+        variables: { locale: next }
+      })
+    })
+
+    if (!response.ok) {
+      throw new Error(`setLocale request failed with status ${response.status}`)
+    }
+
+    const json = await response.json().catch(() => ({}))
+
+    if (json.errors?.length) {
+      throw new Error(json.errors[0]?.message || 'setLocale returned errors')
+    }
+  }
+
+  const handleSelect = async (next) => {
+    if (!isSupportedLocale(next) || next === locale || updating) return
+
+    setUpdating(true)
+    writeLocaleCookie(next)
+
+    try {
+      if (user?.id) {
+        await persistRemoteLocale(next)
+        mutate('/api/user')
+      }
+    } catch (err) {
+      console.error('Failed to persist locale preference', err)
+    } finally {
+      router.replace(router.asPath, undefined, { scroll: false })
+      setUpdating(false)
+    }
+  }
+
+  const currentConfig = LOCALE_CONFIG[locale] || LOCALE_CONFIG.en
+  const triggerLabel = variant === 'inline' ? currentConfig.label : null
+
+  return (
+    <Dropdown
+      trigger={({ onClickToggle }) => (
+        <Button
+          onClick={onClickToggle}
+          className={buttonClassName}
+          title={t('label')}
+          aria-label={t('select')}
+          disabled={updating}
+          loading={updating}
+        >
+          <MdLanguage className={triggerLabel ? 'mr-2' : ''} />
+          {triggerLabel}
+        </Button>
+      )}
+    >
+      {SUPPORTED_LOCALES.map((code) => {
+        const config = LOCALE_CONFIG[code]
+        const label = code === locale ? `${config.label} \u2713` : config.label
+
+        return (
+          <Dropdown.Item
+            key={code}
+            name={label}
+            onClick={() => handleSelect(code)}
+          />
+        )
+      })}
+    </Dropdown>
+  )
+}

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -3,12 +3,15 @@ import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { Fragment, useEffect, isValidElement } from 'react'
 import { FaBars } from 'react-icons/fa'
+import { useTranslations } from 'next-intl'
 import PageContainer from './PageContainer'
 import NavigationOverlay from './NavigationOverlay'
 import { useHashRouteToggle } from '../utils'
 
 export default function Nav ({ leftItems, mobileItems, rightItems, unreadNotificationCount }) {
   const router = useRouter()
+  const t = useTranslations('common')
+  const tNav = useTranslations('nav')
   const [drawerOpen, setDrawerOpen] = useHashRouteToggle('#nav')
 
   const renderMenu = (items = []) => items.map(item => {
@@ -52,8 +55,8 @@ export default function Nav ({ leftItems, mobileItems, rightItems, unreadNotific
         <nav className='flex justify-between items-center py-5 md:justify-start md:space-x-10'>
           <div className='flex justify-start lg:w-0 lg:flex-1'>
             <Link href='/' passHref className='transition-opacity hover:opacity-80'>
-              <span className='sr-only'>Home</span>
-              <Image src={(process.env.BASE_PATH || '') + '/images/banmanager-icon.png'} alt='Logo' width='40' height='40' priority />
+              <span className='sr-only'>{tNav('home')}</span>
+              <Image src={(process.env.BASE_PATH || '') + '/images/banmanager-icon.png'} alt={t('siteName')} width='40' height='40' priority />
             </Link>
           </div>
           <div className='flex items-center justify-center flex-1 lg:w-0'>
@@ -64,7 +67,7 @@ export default function Nav ({ leftItems, mobileItems, rightItems, unreadNotific
               type='button'
               className='rounded-xl w-11 h-11 p-2.5 relative inline-flex items-center justify-center text-gray-200 bg-primary-700 border border-primary-800 hover:bg-primary-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/50'
               onClick={() => setDrawerOpen(true)}
-              aria-label='Open menu'
+              aria-label={tNav('openMenu')}
             >
               <FaBars className='w-5 h-5' />
               {unreadNotificationCount > 0 && (

--- a/components/PlayerLoginPasswordForm.js
+++ b/components/PlayerLoginPasswordForm.js
@@ -1,11 +1,14 @@
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import { MdLock, MdOutlineEmail } from 'react-icons/md'
 import Link from 'next/link'
 import Input from './Input'
 import Button from './Button'
+import { translateRestError } from '../utils/locale'
 
 export default function PlayerLoginPasswordForm ({ onSuccess, showForgotPassword }) {
+  const t = useTranslations()
   const [error, setError] = useState(null)
   const { handleSubmit, formState, register } = useForm()
   const { isSubmitting } = formState
@@ -23,7 +26,7 @@ export default function PlayerLoginPasswordForm ({ onSuccess, showForgotPassword
       if (response.status !== 204) {
         const responseData = await response.json()
 
-        throw new Error(responseData.error)
+        throw translateRestError(t, responseData)
       } else {
         onSuccess()
       }
@@ -37,7 +40,7 @@ export default function PlayerLoginPasswordForm ({ onSuccess, showForgotPassword
       <div className='flex flex-col relative w-full'>
         <Input
           required
-          label='Email address'
+          label={t('forms.email')}
           type='email'
           icon={<MdOutlineEmail />}
           iconPosition='left'
@@ -46,7 +49,7 @@ export default function PlayerLoginPasswordForm ({ onSuccess, showForgotPassword
         />
         <Input
           required
-          label='Password'
+          label={t('forms.password')}
           type='password'
           icon={<MdLock />}
           iconPosition='left'
@@ -57,11 +60,11 @@ export default function PlayerLoginPasswordForm ({ onSuccess, showForgotPassword
         />
         {showForgotPassword && (
           <Link href='/forgotten-password' passHref className='-mt-3 mb-3 text-gray-300'>
-            Forgot password or create account?
+            {t('pages.login.forgotPassword')}
           </Link>
         )}
         <Button data-cy='submit-login-password' disabled={isSubmitting} loading={isSubmitting}>
-          Login
+          {t('common.login')}
         </Button>
       </div>
     </form>

--- a/components/PlayerLoginPinForm.js
+++ b/components/PlayerLoginPinForm.js
@@ -1,15 +1,18 @@
 import { useState } from 'react'
 import { useForm, Controller } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import { AiOutlineUser } from 'react-icons/ai'
 import dynamic from 'next/dynamic'
 import Input from './Input'
 import Button from './Button'
 import ServerSelector from './admin/ServerSelector'
 import { MdPin } from 'react-icons/md'
+import { translateRestError } from '../utils/locale'
 
 const ReactCodeInput = dynamic(() => import('@acusti/react-code-input'), { ssr: false })
 
 export default function PlayerLoginPinForm ({ onSuccess, showHint }) {
+  const t = useTranslations()
   const [error, setError] = useState(null)
   const { handleSubmit, formState, register, control } = useForm()
   const { isSubmitting } = formState
@@ -27,7 +30,7 @@ export default function PlayerLoginPinForm ({ onSuccess, showHint }) {
       if (response.status !== 200) {
         const responseData = await response.json()
 
-        throw new Error(responseData.error)
+        throw translateRestError(t, responseData)
       } else {
         const responseData = await response.json()
 
@@ -50,7 +53,7 @@ export default function PlayerLoginPinForm ({ onSuccess, showHint }) {
         />
         <Input
           required
-          label='Minecraft Username'
+          label={t('forms.username')}
           icon={<AiOutlineUser />}
           iconPosition='left'
           error={error?.message}
@@ -60,9 +63,9 @@ export default function PlayerLoginPinForm ({ onSuccess, showHint }) {
           <div className='flex gap-4 text-left mb-6 rounded-3xl border-primary-900 border-2 p-2'>
             <Button disabled className='w-12 h-12'><MdPin /></Button>
             <div>
-              <p className='underline'>Your 6 digit pin, e.g. <code>123456</code></p>
-              <p className='text-sm text-gray-400'>This can be found when you join the Minecraft server, either on the ban screen or by using the <code className='bg-primary-900'>/bmpin</code> command.</p>
-              <p className='text-sm text-gray-400 mt-2'>Note: this pin expires after 5 minutes.</p>
+              <p className='underline'>{t('pages.appeal.pinHelp')}<code>123456</code></p>
+              <p className='text-sm text-gray-400'>{t.rich('pages.appeal.pinDescription', { command: () => <code className='bg-primary-900'>/bmpin</code> })}</p>
+              <p className='text-sm text-gray-400 mt-2'>{t('pages.appeal.pinExpiry')}</p>
             </div>
           </div>)}
         <Controller
@@ -85,7 +88,7 @@ export default function PlayerLoginPinForm ({ onSuccess, showHint }) {
             </div>)}
         />
         <Button data-cy='submit-login-pin' disabled={isSubmitting} loading={isSubmitting}>
-          Login
+          {t('common.login')}
         </Button>
       </div>
     </form>

--- a/components/PlayerRegisterForm.js
+++ b/components/PlayerRegisterForm.js
@@ -1,19 +1,22 @@
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import { MdLock, MdOutlineEmail } from 'react-icons/md'
 import Input from './Input'
 import Button from './Button'
 import { useRouter } from 'next/router'
+import { translateRestError } from '../utils/locale'
 
 export default function PlayerRegisterForm () {
   const router = useRouter()
+  const t = useTranslations()
   const [error, setError] = useState(null)
   const { handleSubmit, formState, register } = useForm()
   const { isSubmitting } = formState
 
   const onSubmit = async (data) => {
     if (data.password !== data.confirmPassword) {
-      return setError(new Error('Passwords do not match'))
+      return setError(new Error(t('forms.passwordMismatch')))
     }
 
     try {
@@ -28,7 +31,7 @@ export default function PlayerRegisterForm () {
       if (response.status !== 204) {
         const responseData = await response.json()
 
-        throw new Error(responseData.error)
+        throw translateRestError(t, responseData)
       }
 
       router.push('/dashboard')
@@ -42,7 +45,7 @@ export default function PlayerRegisterForm () {
       <div className='flex flex-col relative w-full'>
         <Input
           required
-          label='Email address'
+          label={t('forms.email')}
           minLength={6}
           type='email'
           icon={<MdOutlineEmail />}
@@ -53,18 +56,18 @@ export default function PlayerRegisterForm () {
         />
         <Input
           required
-          label='Password'
+          label={t('forms.password')}
           minLength={6}
           type='password'
           icon={<MdLock />}
           iconPosition='left'
           data-cy='password'
-          description='Must be at least 6 characters long'
+          description={t('forms.minLength', { n: 6 })}
           {...register('password')}
         />
         <Input
           required
-          label='Confirm Password'
+          label={t('forms.confirmPassword')}
           minLength={6}
           type='password'
           icon={<MdLock />}
@@ -74,7 +77,7 @@ export default function PlayerRegisterForm () {
           {...register('confirmPassword')}
         />
         <Button data-cy='submit-register' disabled={isSubmitting} loading={isSubmitting}>
-          Confirm
+          {t('common.continue')}
         </Button>
       </div>
     </form>

--- a/components/Select.js
+++ b/components/Select.js
@@ -1,8 +1,13 @@
 import { forwardRef, useId } from 'react'
 import ReactSelect from 'react-select'
+import { useTranslations } from 'next-intl'
 
 // eslint-disable-next-line react/display-name
-const Select = forwardRef(({ options, isLoading, onInputChange, onChange, value, getOptionValue, noOptionsMessage, isClearable, isSearchable, placeholder = '', filterOption, className = '', defaultValue, ...rest }, ref) => {
+const Select = forwardRef(({ options, isLoading, onInputChange, onChange, value, getOptionValue, noOptionsMessage, loadingMessage, isClearable, isSearchable, placeholder, filterOption, className = '', defaultValue, ...rest }, ref) => {
+  const t = useTranslations('widgets.select')
+  const resolvedNoOptions = noOptionsMessage || (() => t('noOptions'))
+  const resolvedLoading = loadingMessage || (() => t('loading'))
+  const resolvedPlaceholder = placeholder == null ? t('selectPlaceholder') : placeholder
   const DropdownIndicator = ({ innerRef, innerProps }) => (
     <svg className='h-5 w-5 text-gray-400' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor' aria-hidden='true' ref={innerRef} {...innerProps}>
       <path fillRule='evenodd' d='M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z' clipRule='evenodd' />
@@ -23,11 +28,12 @@ const Select = forwardRef(({ options, isLoading, onInputChange, onChange, value,
       defaultValue={defaultValue || setDefaultValue}
       value={options.find((option) => (getOptionValue ? getOptionValue(option) : option.value) === value)}
       filterOption={filterOption}
-      noOptionsMessage={noOptionsMessage}
+      noOptionsMessage={resolvedNoOptions}
+      loadingMessage={resolvedLoading}
       isClearable={isClearable}
       isSearchable={isSearchable}
       components={{ DropdownIndicator, IndicatorSeparator: () => null }}
-      placeholder={placeholder}
+      placeholder={resolvedPlaceholder}
       className={`react_select ${className}`}
       classNamePrefix='react_select'
       ref={ref}

--- a/components/SessionNavProfile.js
+++ b/components/SessionNavProfile.js
@@ -2,9 +2,11 @@ import { useState } from 'react'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { mutate } from 'swr'
+import { useTranslations } from 'next-intl'
 import Dropdown from './Dropdown'
 import Avatar from './Avatar'
 import Button from './Button'
+import LanguageSwitcher from './LanguageSwitcher'
 import NotificationBadge from './NotificationBadge'
 import { MdOutlineNotifications, MdNotifications, MdManageAccounts, MdDashboard, MdOutlineDashboard } from 'react-icons/md'
 import { useUser } from '../utils'
@@ -13,6 +15,9 @@ const buttonClassName = 'bg-primary-900 !rounded-lg p-2 transform transition dur
 
 export default function SessionNavProfile ({ user, unreadNotificationCount }) {
   const router = useRouter()
+  const t = useTranslations('nav')
+  const tCommon = useTranslations('common')
+  const tAccount = useTranslations('pages.account')
   const [loggingOut, setLoggingOut] = useState(false)
   const { hasPermission } = useUser()
 
@@ -43,13 +48,14 @@ export default function SessionNavProfile ({ user, unreadNotificationCount }) {
   return (
     <>
       <div className='hidden md:flex gap-4'>
-        {hasPermission('servers', 'manage') && <Link href='/admin' passHref><Button className={buttonClassName} title='Admin'><MdManageAccounts /></Button></Link>}
+        <LanguageSwitcher buttonClassName={buttonClassName} />
+        {hasPermission('servers', 'manage') && <Link href='/admin' passHref><Button className={buttonClassName} title={t('admin')}><MdManageAccounts /></Button></Link>}
         <Link href='/notifications' passHref>
-          <Button className={buttonClassName} notificationCount={unreadNotificationCount}>
+          <Button className={buttonClassName} notificationCount={unreadNotificationCount} title={t('notifications')}>
             {router.pathname.endsWith('/notifications') ? <MdNotifications /> : <MdOutlineNotifications />}
           </Button>
         </Link>
-        <Link href='/dashboard' passHref><Button className={buttonClassName} title='Dashboard'>{router.pathname.endsWith('/dashboard') ? <MdDashboard /> : <MdOutlineDashboard />}</Button></Link>
+        <Link href='/dashboard' passHref><Button className={buttonClassName} title={t('dashboard')}>{router.pathname.endsWith('/dashboard') ? <MdDashboard /> : <MdOutlineDashboard />}</Button></Link>
         <Dropdown
           trigger={({ onClickToggle }) => (
             <Button
@@ -61,11 +67,11 @@ export default function SessionNavProfile ({ user, unreadNotificationCount }) {
             </Button>
           )}
         >
-          <Dropdown.Item name='Account' href='/account' />
-          {!user.hasAccount && <Dropdown.Item name='Register' href='/account/register' />}
-          <Dropdown.Item name='Profile' href={'/player/' + user.id} />
+          <Dropdown.Item name={t('account')} href='/account' />
+          {!user.hasAccount && <Dropdown.Item name={tAccount('register')} href='/account/register' />}
+          <Dropdown.Item name={t('profile')} href={'/player/' + user.id} />
           <div className='border-primary-400 border-b mx-1' />
-          <Dropdown.Item name='Log out' onClick={handleLogout} disabled={loggingOut} />
+          <Dropdown.Item name={tCommon('logout')} onClick={handleLogout} disabled={loggingOut} />
         </Dropdown>
       </div>
       <div className='md:hidden flex flex-col sm:flex-row sm:justify-around'>
@@ -74,23 +80,23 @@ export default function SessionNavProfile ({ user, unreadNotificationCount }) {
             <Avatar width='48' height='48' uuid={user.id} />
             <div>
               <div className='text-lg font-normal'>{user.name}</div>
-              <div className='text-gray-400 text-sm font-normal'>View profile</div>
+              <div className='text-gray-400 text-sm font-normal'>{t('viewProfile')}</div>
             </div>
           </div>
         </Link>
         <span className='text-5xl mb-2 border-b border-primary-400 leading-none' />
-        <Dropdown.Item name='Account' href='/account' className='px-2 mb-2 m-0' />
-        <Dropdown.Item name='Dashboard' href='/dashboard' className='px-2 mb-2' />
-        <Dropdown.Item name='Notifications' href='/notifications' className='px-2 mb-2'>
+        <Dropdown.Item name={t('account')} href='/account' className='px-2 mb-2 m-0' />
+        <Dropdown.Item name={t('dashboard')} href='/dashboard' className='px-2 mb-2' />
+        <Dropdown.Item name={t('notifications')} href='/notifications' className='px-2 mb-2'>
           {unreadNotificationCount > 0 && <NotificationBadge>{unreadNotificationCount > 9 ? '9+' : unreadNotificationCount}</NotificationBadge>}
         </Dropdown.Item>
-        <Dropdown.Item name='Profile' href={'/player/' + user.id} className='px-2 mb-2' />
+        <Dropdown.Item name={t('profile')} href={'/player/' + user.id} className='px-2 mb-2' />
         <span className='text-5xl mb-2 border-b border-primary-400 leading-none' />
-        <Dropdown.Item name='Log out' onClick={handleLogout} disabled={loggingOut} className='px-2 mb-2' />
+        <Dropdown.Item name={tCommon('logout')} onClick={handleLogout} disabled={loggingOut} className='px-2 mb-2' />
         {hasPermission('servers', 'manage') && (
           <>
             <span className='text-5xl mb-2 border-b border-primary-400 leading-none' />
-            <Dropdown.Item name='Admin' href='/admin' className='px-2' />
+            <Dropdown.Item name={t('admin')} href='/admin' className='px-2' />
           </>)}
       </div>
     </>

--- a/components/Time.js
+++ b/components/Time.js
@@ -1,22 +1,45 @@
-import { format, formatDistance, formatDuration, formatISODuration, fromUnixTime, intervalToDuration } from 'date-fns'
-import { fromNow } from '../utils'
-import { formatDistanceLocale } from '../utils/format-distance'
+import { format, formatDistance, formatDistanceStrict, formatDuration, formatISODuration, fromUnixTime, intervalToDuration } from 'date-fns'
+import { formatDistanceLocale, useDateFnsLocale } from '../utils/format-distance'
+
+const safeFormat = (date, pattern, locale) => {
+  try {
+    return format(date, pattern, locale ? { locale } : undefined)
+  } catch (e) {
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.warn('[i18n] date-fns format failed, falling back to default locale:', { pattern, localeCode: locale?.code, error: e?.message })
+    }
+
+    return format(date, pattern)
+  }
+}
 
 export function TimeFromNow ({ timestamp }) {
-  const formatted = format(fromUnixTime(timestamp), 'd MMM yyyy, H:mm z')
+  const dateFnsLocale = useDateFnsLocale()
+  const date = fromUnixTime(timestamp)
+  const formatted = safeFormat(date, 'd MMM yyyy, H:mm z', dateFnsLocale)
+
+  let relative
+
+  try {
+    relative = formatDistanceStrict(date, new Date(), { addSuffix: true, locale: dateFnsLocale || undefined })
+  } catch (e) {
+    relative = timestamp
+  }
 
   return (
     <time
-      dateTime={fromUnixTime(timestamp).toISOString()}
+      dateTime={date.toISOString()}
       title={formatted}
     >
-      {fromNow(timestamp)}
+      {relative}
     </time>
   )
 }
 
 export function Time ({ timestamp }) {
-  const formatted = format(fromUnixTime(timestamp), 'd MMM yyyy, H:mm z')
+  const dateFnsLocale = useDateFnsLocale()
+  const formatted = safeFormat(fromUnixTime(timestamp), 'd MMM yyyy, H:mm z', dateFnsLocale)
 
   return (
     <time
@@ -29,12 +52,13 @@ export function Time ({ timestamp }) {
 }
 
 export function TimeDuration ({ startTimestamp, endTimestamp }) {
+  const dateFnsLocale = useDateFnsLocale()
   const duration = intervalToDuration({
     start: fromUnixTime(startTimestamp),
     end: fromUnixTime(endTimestamp)
   })
-  const exactFormatted = formatDuration(duration)
-  const formatted = formatDistance(fromUnixTime(startTimestamp), fromUnixTime(endTimestamp))
+  const exactFormatted = formatDuration(duration, dateFnsLocale ? { locale: dateFnsLocale } : undefined)
+  const formatted = formatDistance(fromUnixTime(startTimestamp), fromUnixTime(endTimestamp), dateFnsLocale ? { locale: dateFnsLocale } : undefined)
 
   return (
     <time
@@ -47,11 +71,12 @@ export function TimeDuration ({ startTimestamp, endTimestamp }) {
 }
 
 export function TimeDurationAbbreviated ({ startTimestamp, endTimestamp }) {
+  const dateFnsLocale = useDateFnsLocale()
   const duration = intervalToDuration({
     start: fromUnixTime(startTimestamp),
     end: fromUnixTime(endTimestamp)
   })
-  const exactFormatted = formatDuration(duration)
+  const exactFormatted = formatDuration(duration, dateFnsLocale ? { locale: dateFnsLocale } : undefined)
   const formatted = formatDistance(fromUnixTime(startTimestamp), fromUnixTime(endTimestamp), { locale: { formatDistance: formatDistanceLocale } })
 
   return (

--- a/components/admin/PlayerSelector.js
+++ b/components/admin/PlayerSelector.js
@@ -1,10 +1,14 @@
 import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import Select from '../Select'
 import { useMutateApi } from '../../utils'
 import Avatar from '../Avatar'
 
 // eslint-disable-next-line react/display-name
-const PlayerSelector = forwardRef(({ clearable = false, onChange, multiple = true, value, options: defaultOptions = [], placeholder = 'Select players', limit = 5, ...rest }, ref) => {
+const PlayerSelector = forwardRef(({ clearable = false, onChange, multiple = true, value, options: defaultOptions = [], placeholder, limit = 5, ...rest }, ref) => {
+  const tWidgets = useTranslations('widgets.select')
+  const tForms = useTranslations('forms')
+  const resolvedPlaceholder = placeholder == null ? tForms('playerSelectorPlaceholder') : placeholder
   const [name, setName] = useState('')
   const [options, setOptions] = useState(defaultOptions)
   const [selected, setSelected] = useState(multiple ? [] : value || null)
@@ -47,7 +51,10 @@ const PlayerSelector = forwardRef(({ clearable = false, onChange, multiple = tru
   }, [data])
 
   const filterOption = useCallback(() => true, [])
-  const noOptionsMessage = useMemo(() => (loading ? () => 'Loading…' : () => 'No players found'), [loading])
+  const noOptionsMessage = useMemo(
+    () => (loading ? () => tWidgets('loading') : () => tWidgets('noPlayersFound')),
+    [loading, tWidgets]
+  )
   const handlePlayerChange = (selectedOptions) => {
     if (selectedOptions?.value) return setSelected(selectedOptions.value)
 
@@ -70,7 +77,7 @@ const PlayerSelector = forwardRef(({ clearable = false, onChange, multiple = tru
       filterOption={filterOption}
       noOptionsMessage={noOptionsMessage}
       isClearable={clearable}
-      placeholder={placeholder}
+      placeholder={resolvedPlaceholder}
       isMulti={multiple}
       {...rest}
     />

--- a/components/admin/webhooks/DiscordPreview.js
+++ b/components/admin/webhooks/DiscordPreview.js
@@ -2,8 +2,12 @@
 import { toHTML } from '@odiffey/discord-markdown'
 import fillTemplate from 'es6-dynamic-template'
 import Image from 'next/image'
+import { useFormatter, useTranslations } from 'next-intl'
 
 export default function DiscordPreview ({ json, variables }) {
+  const format = useFormatter()
+  const t = useTranslations('errors')
+
   if (!json) return null
 
   let content = json
@@ -15,8 +19,10 @@ export default function DiscordPreview ({ json, variables }) {
   try {
     content = JSON.parse(content)
   } catch (e) {
-    return <div className='text-red-500'>Invalid JSON</div>
+    return <div className='text-red-500'>{t('invalidJson')}</div>
   }
+
+  const formatTimestamp = (value) => format.dateTime(new Date(value), { dateStyle: 'medium', timeStyle: 'short' })
 
   return (
     <div className='discord-preview shrink'>
@@ -27,7 +33,7 @@ export default function DiscordPreview ({ json, variables }) {
         <div className='grow'>
           <p className='leading-none h-5'>
             <span className='hover:underline cursor-pointer underline-offset-1 decoration-1 font-medium text-[#f2f3f5] text-base'>BanManager</span>
-            <span className='font-medium ml-1 cursor-default text-xs align-baseline text-[#949BA4]'>{new Date(content.timestamp || Date.now()).toLocaleString()}</span>
+            <span className='font-medium ml-1 cursor-default text-xs align-baseline text-[#949BA4]'>{formatTimestamp(content.timestamp || Date.now())}</span>
           </p>
           {content.content && <div className='discord-content' dangerouslySetInnerHTML={{ __html: toHTML(content.content) }} />}
           {content.embeds && (
@@ -53,7 +59,7 @@ export default function DiscordPreview ({ json, variables }) {
                   <div className='discord-embed-footer'>
                     {embed.footer.icon_url && <img src={embed.footer.icon_url} alt='footer icon' className='discord-embed-footer-icon' />}
                     <span>{embed.footer.text}</span>
-                    {embed.timestamp && <span>{new Date(embed.timestamp).toLocaleString()}</span>}
+                    {embed.timestamp && <span>{formatTimestamp(embed.timestamp)}</span>}
                   </div>
                 )}
               </div>))}

--- a/components/appeal/AppealStepHeader.js
+++ b/components/appeal/AppealStepHeader.js
@@ -1,12 +1,15 @@
+import { useTranslations } from 'next-intl'
 import RadialProgressBar from '../RadialProgressBar'
 
 export default function AppealStepHeader ({ step, title, nextStep }) {
+  const t = useTranslations('components.appealStep')
+
   return (
     <div className='flex items-center gap-4 border-b border-accent-400 mb-4'>
-      <RadialProgressBar size={24} radius={30} progress={(100 / 3) * step} title={`${step} of 3`} />
+      <RadialProgressBar size={24} radius={30} progress={(100 / 3) * step} title={t('progress', { step, total: 3 })} />
       <div>
         <p className='text-2xl font-bold'>{title}</p>
-        <p className='text-sm'>Next: {nextStep}</p>
+        <p className='text-sm'>{t('next', { next: nextStep })}</p>
       </div>
     </div>
   )

--- a/components/notifications/NotificationAppealAssigned.js
+++ b/components/notifications/NotificationAppealAssigned.js
@@ -1,16 +1,22 @@
+import { useTranslations } from 'next-intl'
 import { useUser } from '../../utils'
 import NotificationContainer from './NotificationContainer'
 import PlayerAppealBadge from '../appeals/PlayerAppealBadge'
 
 export default function NotificationAppealAssigned ({ id, actor, created, state, appeal }) {
+  const t = useTranslations('notifications')
   const { user } = useUser()
+  const ownAppeal = appeal.actor.id === user?.id
+  const messageKey = ownAppeal ? 'appealAssignedOwn' : 'appealAssignedOther'
 
   return (
     <NotificationContainer id={id} actor={actor} created={created} state={state}>
       <p className='text-sm'>
-        {appeal.actor.id === user?.id
-          ? <>{actor.name} assigned <span className='font-semibold'>{appeal.assignee.name}</span> to review your appeal</>
-          : <><span className='font-semibold'>{actor.name}</span> assigned <span className='font-semibold'>{appeal.assignee.name}</span> to review appeal</>}
+        {t.rich(messageKey, {
+          actor: actor.name,
+          assignee: appeal.assignee.name,
+          b: (chunks) => <span className='font-semibold'>{chunks}</span>
+        })}
       </p>
       <div className='flex items-center gap-3'>
         <PlayerAppealBadge appeal={appeal} className='text-sm'>#{appeal.id}</PlayerAppealBadge>

--- a/components/notifications/NotificationAppealComment.js
+++ b/components/notifications/NotificationAppealComment.js
@@ -1,16 +1,18 @@
+import { useTranslations } from 'next-intl'
 import { useUser } from '../../utils'
 import PlayerAppealBadge from '../appeals/PlayerAppealBadge'
 import NotificationContainer from './NotificationContainer'
 
 export default function NotificationAppealComment ({ id, actor, created, comment, state, appeal }) {
+  const t = useTranslations('notifications')
   const { user } = useUser()
+  const ownAppeal = appeal.actor.id === user?.id
+  const messageKey = ownAppeal ? 'appealCommentOwn' : 'appealCommentOther'
 
   return (
     <NotificationContainer id={id} actor={actor} created={created} state={state}>
       <p className='text-sm'>
-        {appeal.actor.id === user?.id
-          ? <>{actor.name} commented on your appeal</>
-          : <><span className='font-semibold'>{actor.name}</span> added a comment</>}
+        {t.rich(messageKey, { name: actor.name, b: (chunks) => <span className='font-semibold'>{chunks}</span> })}
       </p>
       <div className='flex justify-start items-center gap-3'>
         <PlayerAppealBadge appeal={appeal} className='text-sm'>#{appeal.id}</PlayerAppealBadge>

--- a/components/notifications/NotificationAppealCreated.js
+++ b/components/notifications/NotificationAppealCreated.js
@@ -1,9 +1,12 @@
+import { useTranslations } from 'next-intl'
 import NotificationContainer from './NotificationContainer'
 
 export default function NotificationAppealCreated ({ id, actor, created, state, appeal }) {
+  const t = useTranslations('notifications')
+
   return (
     <NotificationContainer id={id} actor={actor} created={created} state={state}>
-      <p className='text-sm'><span className='font-semibold'>{actor.name}</span> created an appeal</p>
+      <p className='text-sm'>{t.rich('appealCreated', { name: actor.name, b: (chunks) => <span className='font-semibold'>{chunks}</span> })}</p>
       <blockquote className='px-3 text-ellipsis line-clamp-2 my-4 border-s-2 border-gray-400 text-gray-400'>{appeal?.reason}</blockquote>
     </NotificationContainer>
   )

--- a/components/notifications/NotificationAppealState.js
+++ b/components/notifications/NotificationAppealState.js
@@ -1,16 +1,31 @@
+import { useTranslations } from 'next-intl'
 import { useUser } from '../../utils'
 import PlayerAppealBadge from '../appeals/PlayerAppealBadge'
 import NotificationContainer from './NotificationContainer'
 
+const localiseStateName = (t, name) => {
+  if (!name) return ''
+
+  const key = name === 'Open' ? 'open' : name.toLowerCase()
+
+  return t.has(`stateLabels.${key}`) ? t(`stateLabels.${key}`) : key
+}
+
 export default function NotificationAppealState ({ id, actor, created, state, appeal }) {
+  const t = useTranslations('notifications')
   const { user } = useUser()
+  const ownAppeal = appeal.actor.id === user?.id
+  const messageKey = ownAppeal ? 'appealStateOwn' : 'appealStateOther'
+  const localisedState = localiseStateName(t, appeal.state.name)
 
   return (
     <NotificationContainer id={id} actor={actor} created={created} state={state}>
       <p className='text-sm'>
-        {appeal.actor.id === user?.id
-          ? <>{actor.name} <span className='font-semibold'>{appeal.state.name === 'Open' ? 'opened' : appeal.state.name.toLowerCase()}</span> your appeal</>
-          : <>{actor.name} <span className='font-semibold'>{appeal.state.name === 'Open' ? 'opened' : appeal.state.name.toLowerCase()}</span> appeal</>}
+        {t.rich(messageKey, {
+          actor: actor.name,
+          state: localisedState,
+          b: (chunks) => <span className='font-semibold'>{chunks}</span>
+        })}
       </p>
       <div className='flex items-center gap-3'>
         <PlayerAppealBadge appeal={appeal} className='text-sm'>#{appeal.id}</PlayerAppealBadge>

--- a/components/notifications/NotificationContainer.js
+++ b/components/notifications/NotificationContainer.js
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import Link from 'next/link'
+import { formatDistanceStrict, fromUnixTime } from 'date-fns'
 import Avatar from '../Avatar'
-import { fromNow } from '../../utils'
 import { formatDistanceLocale } from '../../utils/format-distance'
 
 export default function NotificationContainer ({ id, actor, created, children, state }) {
@@ -15,6 +15,18 @@ export default function NotificationContainer ({ id, actor, created, children, s
   {
     'border-accent-600': state === 'unread'
   })
+
+  let label
+
+  try {
+    label = formatDistanceStrict(fromUnixTime(created), new Date(), {
+      addSuffix: false,
+      locale: { formatDistance: formatDistanceLocale }
+    })
+  } catch (e) {
+    label = created
+  }
+
   return (
     <Link
       href={`/api/notifications/${id}`}
@@ -34,7 +46,7 @@ export default function NotificationContainer ({ id, actor, created, children, s
           {children}
         </div>
         <div className='w-6 justify-end'>
-          <p className='text-gray-400 text-xs mr-3'>{fromNow(created, { locale: { formatDistance: formatDistanceLocale } })}</p>
+          <p className='text-gray-400 text-xs mr-3'>{label}</p>
         </div>
       </div>
     </Link>

--- a/components/notifications/NotificationReportAssigned.js
+++ b/components/notifications/NotificationReportAssigned.js
@@ -1,16 +1,23 @@
+import { useTranslations } from 'next-intl'
 import { useUser } from '../../utils'
 import PlayerAppealBadge from '../appeals/PlayerAppealBadge'
 import NotificationContainer from './NotificationContainer'
 
 export default function NotificationReportAssigned ({ id, actor, created, state, report }) {
+  const t = useTranslations('notifications')
   const { user } = useUser()
+  const ownReport = report.actor.id === user?.id
+  const messageKey = ownReport ? 'reportAssignedOwn' : 'reportAssignedOther'
 
   return (
     <NotificationContainer id={id} actor={actor} created={created} state={state}>
       <p className='text-sm'>
-        {report.actor.id === user?.id
-          ? <>{actor.name} assigned <span className='font-semibold'>{report.assignee.name}</span> to review your report against {report.player.name}</>
-          : <><span className='font-semibold'>{actor.name}</span> assigned <span className='font-semibold'>{report.assignee.name}</span> to review report</>}
+        {t.rich(messageKey, {
+          actor: actor.name,
+          assignee: report.assignee.name,
+          player: report.player.name,
+          b: (chunks) => <span className='font-semibold'>{chunks}</span>
+        })}
       </p>
       <div className='flex items-center gap-3'>
         <PlayerAppealBadge appeal={{}} className='text-sm'>#{report.id}</PlayerAppealBadge>

--- a/components/notifications/NotificationReportComment.js
+++ b/components/notifications/NotificationReportComment.js
@@ -1,15 +1,17 @@
+import { useTranslations } from 'next-intl'
 import { useUser } from '../../utils'
 import NotificationContainer from './NotificationContainer'
 
 export default function NotificationReportComment ({ id, actor, created, state, report, comment }) {
+  const t = useTranslations('notifications')
   const { user } = useUser()
+  const ownReport = report.actor.id === user?.id
+  const messageKey = ownReport ? 'reportCommentOwn' : 'reportCommentOther'
 
   return (
     <NotificationContainer id={id} actor={actor} created={created} state={state}>
       <p className='text-sm'>
-        {report.actor.id === user?.id
-          ? <>{actor.name} commented on your report</>
-          : <><span className='font-semibold'>{actor.name}</span> added a comment</>}
+        {t.rich(messageKey, { name: actor.name, b: (chunks) => <span className='font-semibold'>{chunks}</span> })}
       </p>
       <div className='flex justify-start items-center gap-3'>
         <blockquote className='px-3 text-ellipsis line-clamp-1 my-4 border-s-2 border-gray-400 text-gray-400'>{comment.content}</blockquote>

--- a/components/notifications/NotificationReportState.js
+++ b/components/notifications/NotificationReportState.js
@@ -1,16 +1,31 @@
+import { useTranslations } from 'next-intl'
 import NotificationContainer from './NotificationContainer'
 import PlayerAppealBadge from '../appeals/PlayerAppealBadge'
 import { useUser } from '../../utils'
 
+const localiseStateName = (t, name) => {
+  if (!name) return ''
+
+  const key = name === 'Open' ? 'open' : name.toLowerCase()
+
+  return t.has(`stateLabels.${key}`) ? t(`stateLabels.${key}`) : key
+}
+
 export default function NotificationReportState ({ id, actor, created, state, report }) {
+  const t = useTranslations('notifications')
   const { user } = useUser()
+  const ownReport = report.actor.id === user?.id
+  const messageKey = ownReport ? 'reportStateOwn' : 'reportStateOther'
+  const localisedState = localiseStateName(t, report.state.name)
 
   return (
     <NotificationContainer id={id} actor={actor} created={created} state={state}>
       <p className='text-sm'>
-        {report.actor.id === user?.id
-          ? <>{actor.name} <span className='font-semibold'>{report.state.name === 'Open' ? 'opened' : report.state.name.toLowerCase()}</span> your report</>
-          : <>{actor.name} <span className='font-semibold'>{report.state.name === 'Open' ? 'opened' : report.state.name.toLowerCase()}</span> report</>}
+        {t.rich(messageKey, {
+          actor: actor.name,
+          state: localisedState,
+          b: (chunks) => <span className='font-semibold'>{chunks}</span>
+        })}
       </p>
       <div className='flex items-center gap-3'>
         <PlayerAppealBadge appeal={{}} className='text-sm'>#{report.id}</PlayerAppealBadge>

--- a/messages/de.json
+++ b/messages/de.json
@@ -122,6 +122,7 @@
     "INVALID_INPUT": "Ungültige Eingabe",
     "INVALID_EMAIL": "E-Mail-Adresse ist ungültig",
     "INVALID_PASSWORD": "Passwort ist ungültig",
+    "INVALID_PASSWORD_LENGTH": "Ungültiges Passwort, mindestens {minLength} Zeichen",
     "INVALID_LOCALE": "Sprache wird nicht unterstützt",
     "EMAIL_IN_USE": "E-Mail wird bereits verwendet",
     "PASSWORD_BREACHED": "Dieses Passwort ist nicht sicher, da es in {count, plural, one {# bekannten Datenleck} other {# bekannten Datenlecks}} aufgetaucht ist",

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,0 +1,221 @@
+{
+  "common": {
+    "login": "Anmelden",
+    "logout": "Abmelden",
+    "cancel": "Abbrechen",
+    "save": "Speichern",
+    "submit": "Absenden",
+    "delete": "Löschen",
+    "edit": "Bearbeiten",
+    "back": "Zurück",
+    "continue": "Weiter",
+    "loading": "Wird geladen…",
+    "search": "Suchen",
+    "yes": "Ja",
+    "no": "Nein",
+    "ok": "OK",
+    "siteName": "Ban Management",
+    "version": "Version"
+  },
+  "nav": {
+    "login": "Anmelden",
+    "createAppeal": "Einspruch erstellen",
+    "language": "Sprache",
+    "home": "Startseite",
+    "openMenu": "Menü öffnen",
+    "admin": "Administration",
+    "dashboard": "Dashboard",
+    "notifications": "Benachrichtigungen",
+    "account": "Konto",
+    "profile": "Profil",
+    "viewProfile": "Profil anzeigen"
+  },
+  "footer": {
+    "powered": "Bereitgestellt von"
+  },
+  "pages": {
+    "login": {
+      "title": "Anmelden",
+      "subtitle": "Willkommen zurück",
+      "forgotPassword": "Passwort vergessen oder Konto erstellen?"
+    },
+    "register": {
+      "title": "Registrieren",
+      "subtitle": "Erstelle dein Konto"
+    },
+    "forgottenPassword": {
+      "title": "Passwort vergessen",
+      "subtitle": "Wir senden dir einen Reset-Link per E-Mail"
+    },
+    "appeal": {
+      "title": "Einspruch erstellen",
+      "subtitle": "Reiche einen Einspruch gegen eine Strafe ein",
+      "documentTitle": "Einspruch",
+      "stepHeader": {
+        "step1": "PIN-Anmeldung",
+        "selectPunishment": "Strafe auswählen"
+      },
+      "intro": "Zuerst müssen wir wissen, wer du bist.",
+      "pinHelp": "Ich habe einen 6-stelligen PIN, z.B. ",
+      "pinDescription": "Dieser ist verfügbar, wenn du den Minecraft-Server betrittst, entweder im Bann-Bildschirm oder mit dem {command}-Befehl.",
+      "pinExpiry": "Hinweis: Dieser PIN läuft nach 5 Minuten ab.",
+      "or": "ODER",
+      "haveAccount": "Ich habe bereits ein Konto",
+      "haveAccountDescription": "Dies ist spezifisch für diese Website und NICHT deine Microsoft/Mojang-Anmeldedaten."
+    },
+    "account": {
+      "documentTitle": "Konto",
+      "subtitle": "Konto",
+      "register": "Registrieren",
+      "email": "E-Mail",
+      "password": "Passwort"
+    },
+    "notFound": {
+      "title": "Hoppla! Seite nicht gefunden",
+      "subtitle": "Ein Fehler ist aufgetreten",
+      "documentTitle": "Nicht gefunden",
+      "intro": "Sieht aus, als hättest du dich verlaufen! Diese Seite scheint sich versteckt zu haben.",
+      "directions": "Lass uns gemeinsam zurückfinden:",
+      "homepage": "Zur Startseite",
+      "homepageHint": " - starte ein neues Abenteuer!",
+      "search": "Verwende die Suchleiste oben, um zu finden, was du suchst.",
+      "back": "Versuche, zur vorherigen Seite zurückzukehren."
+    },
+    "serverError": {
+      "title": "Serverfehler",
+      "subtitle": "Etwas ist schiefgelaufen",
+      "intro": "Es tut uns leid, bei uns ist etwas schiefgelaufen. Bitte versuche es später erneut.",
+      "documentTitle": "Serverfehler"
+    },
+    "admin": {
+      "title": "Administration",
+      "developerMode": "Entwicklermodus",
+      "developerModeMessage": "Du läufst aktuell im Entwicklungsmodus, erwarte Leistungseinbußen",
+      "updateAvailable": "Update verfügbar",
+      "currentVersion": "Aktuelle Version: {current}",
+      "latestVersion": "Neueste: {latest}",
+      "newFeatures": "Neue Funktionen",
+      "fixes": "Fehlerbehebungen"
+    }
+  },
+  "errors": {
+    "header": "Fehler",
+    "fetchHeader": "Abruffehler",
+    "httpHeader": "HTTP-Fehler: {status}",
+    "invalidJson": "Ungültiges JSON",
+    "INTERNAL": "Interner Serverfehler",
+    "UNKNOWN": "Ein unbekannter Fehler ist aufgetreten",
+    "NO_PERMISSION": "Du hast keine Berechtigung, diese Aktion auszuführen",
+    "NOT_LOGGED_IN": "Du bist nicht angemeldet",
+    "SERVER_NOT_FOUND": "Server nicht gefunden",
+    "PLAYER_NOT_FOUND": "Spieler nicht gefunden",
+    "ROLE_NOT_FOUND": "Rolle nicht gefunden",
+    "REPORT_NOT_FOUND": "Meldung nicht gefunden",
+    "APPEAL_NOT_FOUND": "Einspruch nicht gefunden",
+    "BAN_NOT_FOUND": "Bann nicht gefunden",
+    "MUTE_NOT_FOUND": "Stummschaltung nicht gefunden",
+    "WARNING_NOT_FOUND": "Verwarnung nicht gefunden",
+    "NOTE_NOT_FOUND": "Notiz nicht gefunden",
+    "WEBHOOK_NOT_FOUND": "Webhook nicht gefunden",
+    "RULE_NOT_FOUND": "Regel nicht gefunden",
+    "DOCUMENT_NOT_FOUND": "Dokument nicht gefunden",
+    "INVALID_INPUT": "Ungültige Eingabe",
+    "INVALID_EMAIL": "E-Mail-Adresse ist ungültig",
+    "INVALID_PASSWORD": "Passwort ist ungültig",
+    "INVALID_LOCALE": "Sprache wird nicht unterstützt",
+    "EMAIL_IN_USE": "E-Mail wird bereits verwendet",
+    "PASSWORD_BREACHED": "Dieses Passwort ist nicht sicher, da es in {count, plural, one {# bekannten Datenleck} other {# bekannten Datenlecks}} aufgetaucht ist",
+    "PASSWORD_COMPROMISED": "Dieses Passwort ist nicht sicher, da es in {count, plural, one {# bekannten Datenleck} other {# bekannten Datenlecks}} aufgetaucht ist",
+    "RATE_LIMIT": "Zu viele Versuche. Bitte versuche es später erneut.",
+    "DUPLICATE_APPEAL": "Du hast bereits einen offenen Einspruch für diese Strafe",
+    "ALREADY_RESOLVED": "Dies wurde bereits bearbeitet",
+    "ALREADY_EXISTS": "Dies existiert bereits",
+    "INVALID_NAME": "Name ist ungültig",
+    "INVALID_PIN": "PIN ist ungültig",
+    "INVALID_TARGET": "Du kannst diese Aktion nicht an dir selbst ausführen",
+    "INVALID_STATE": "Ungültiger Statuswechsel",
+    "INCORRECT_LOGIN": "Falsche Anmeldedaten",
+    "REPORT_COMMENT_NOT_FOUND": "Meldungskommentar nicht gefunden",
+    "APPEAL_COMMENT_NOT_FOUND": "Einspruchskommentar nicht gefunden",
+    "USER_NOT_FOUND": "Benutzer nicht gefunden",
+    "NOTIFICATION_NOT_FOUND": "Benachrichtigung nicht gefunden",
+    "PUNISHMENT_NOT_FOUND": "Strafe nicht gefunden",
+    "PUNISHMENT_NOT_ACTIVE": "Diese Strafe ist nicht mehr aktiv",
+    "REPORT_STATE_NOT_FOUND": "Meldungsstatus nicht gefunden",
+    "APPEAL_STATE_NOT_FOUND": "Einspruchsstatus nicht gefunden",
+    "MUTE_RECORD_NOT_FOUND": "Stummschaltungseintrag nicht gefunden",
+    "BAN_RECORD_NOT_FOUND": "Banneintrag nicht gefunden",
+    "KICK_NOT_FOUND": "Kick nicht gefunden",
+    "INTERVAL_TOO_LARGE": "Der angeforderte Zeitraum ist zu groß",
+    "LIMIT_TOO_LARGE": "Das angeforderte Limit ist zu groß",
+    "OFFSET_OUT_OF_RANGE": "Offset überschreitet die verfügbaren Daten",
+    "DB_CONNECTION_ERROR": "Verbindung zur Datenbank fehlgeschlagen",
+    "MISSING_DATABASE_TABLES": "Erforderliche Datenbanktabellen fehlen",
+    "CONSOLE_UUID_NOT_FOUND": "Konsolen-Spieler nicht gefunden",
+    "EXAMPLE_PAYLOAD_NOT_FOUND": "Beispielpayload nicht gefunden",
+    "CANNOT_DELETE_LAST_SERVER": "Du kannst den letzten Server nicht löschen",
+    "DEFAULT_ROLE_PROTECTED": "Die Standardrolle kann nicht geändert werden",
+    "DEFAULT_ROLE_PARENT_FORBIDDEN": "Die Standardrolle kann kein übergeordnetes Element sein",
+    "NO_ACCOUNT": "Mit dieser E-Mail ist kein Konto verknüpft",
+    "SUBSCRIPTION_EXISTS": "Abonnement existiert bereits",
+    "SERVER_PERMISSION_DENIED": "Du hast keinen Zugriff auf diesen Server"
+  },
+  "forms": {
+    "email": "E-Mail-Adresse",
+    "password": "Passwort",
+    "currentPassword": "Aktuelles Passwort",
+    "newPassword": "Neues Passwort",
+    "confirmPassword": "Passwort bestätigen",
+    "username": "Benutzername",
+    "name": "Name",
+    "reason": "Grund",
+    "message": "Nachricht",
+    "comment": "Schreibe hier deinen Kommentar…",
+    "playerSelectorPlaceholder": "Spieler suchen",
+    "required": "Dieses Feld ist erforderlich",
+    "minLength": "Muss mindestens {n} Zeichen lang sein",
+    "maxLength": "Darf maximal {n} Zeichen lang sein",
+    "passwordMismatch": "Passwörter stimmen nicht überein"
+  },
+  "widgets": {
+    "select": {
+      "noOptions": "Keine Optionen",
+      "noPlayersFound": "Keine Spieler gefunden",
+      "selectPlaceholder": "Auswählen…",
+      "loading": "Wird geladen…"
+    },
+    "languageSwitcher": {
+      "label": "Sprache",
+      "select": "Sprache auswählen"
+    }
+  },
+  "components": {
+    "appealStep": {
+      "progress": "{step} von {total}",
+      "next": "Weiter: {next}"
+    }
+  },
+  "notifications": {
+    "appealCreated": "<b>{name}</b> hat einen Einspruch erstellt",
+    "appealCommentOwn": "<b>{name}</b> hat deinen Einspruch kommentiert",
+    "appealCommentOther": "<b>{name}</b> hat einen Kommentar hinzugefügt",
+    "appealAssignedOwn": "{actor} hat <b>{assignee}</b> mit der Prüfung deines Einspruchs beauftragt",
+    "appealAssignedOther": "<b>{actor}</b> hat <b>{assignee}</b> mit der Prüfung des Einspruchs beauftragt",
+    "appealStateOwn": "{actor} hat deinen Einspruch <b>{state}</b>",
+    "appealStateOther": "{actor} hat Einspruch <b>{state}</b>",
+    "reportCommentOwn": "{name} hat deine Meldung kommentiert",
+    "reportCommentOther": "<b>{name}</b> hat einen Kommentar hinzugefügt",
+    "reportAssignedOwn": "{actor} hat <b>{assignee}</b> mit der Prüfung deiner Meldung gegen {player} beauftragt",
+    "reportAssignedOther": "<b>{actor}</b> hat <b>{assignee}</b> mit der Prüfung der Meldung beauftragt",
+    "reportStateOwn": "{actor} hat deine Meldung <b>{state}</b>",
+    "reportStateOther": "{actor} hat Meldung <b>{state}</b>",
+    "stateLabels": {
+      "open": "geöffnet",
+      "closed": "geschlossen",
+      "approved": "genehmigt",
+      "denied": "abgelehnt",
+      "resolved": "gelöst",
+      "unresolved": "ungelöst"
+    }
+  }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,221 @@
+{
+  "common": {
+    "login": "Login",
+    "logout": "Logout",
+    "cancel": "Cancel",
+    "save": "Save",
+    "submit": "Submit",
+    "delete": "Delete",
+    "edit": "Edit",
+    "back": "Back",
+    "continue": "Continue",
+    "loading": "Loading…",
+    "search": "Search",
+    "yes": "Yes",
+    "no": "No",
+    "ok": "OK",
+    "siteName": "Ban Management",
+    "version": "Version"
+  },
+  "nav": {
+    "login": "Login",
+    "createAppeal": "Create Appeal",
+    "language": "Language",
+    "home": "Home",
+    "openMenu": "Open menu",
+    "admin": "Admin",
+    "dashboard": "Dashboard",
+    "notifications": "Notifications",
+    "account": "Account",
+    "profile": "Profile",
+    "viewProfile": "View profile"
+  },
+  "footer": {
+    "powered": "Powered by"
+  },
+  "pages": {
+    "login": {
+      "title": "Login",
+      "subtitle": "Welcome back",
+      "forgotPassword": "Forgot password or create account?"
+    },
+    "register": {
+      "title": "Register",
+      "subtitle": "Create your account"
+    },
+    "forgottenPassword": {
+      "title": "Forgotten Password",
+      "subtitle": "We'll email you a reset link"
+    },
+    "appeal": {
+      "title": "Create Appeal",
+      "subtitle": "Submit a punishment appeal",
+      "documentTitle": "Appeal",
+      "stepHeader": {
+        "step1": "Pin Login",
+        "selectPunishment": "Select Punishment"
+      },
+      "intro": "First, we need to know who you are.",
+      "pinHelp": "I have a 6 digit pin, e.g. ",
+      "pinDescription": "This can be found when you join the Minecraft server, either on the ban screen or by using the {command} command.",
+      "pinExpiry": "Note: this pin expires after 5 minutes.",
+      "or": "OR",
+      "haveAccount": "I already have an account",
+      "haveAccountDescription": "This is specific for this website and NOT your Microsoft/Mojang credentials."
+    },
+    "account": {
+      "documentTitle": "Account",
+      "subtitle": "Account",
+      "register": "Register",
+      "email": "Email",
+      "password": "Password"
+    },
+    "notFound": {
+      "title": "Oops! Page Not Found",
+      "subtitle": "An error occurred",
+      "documentTitle": "Not Found",
+      "intro": "Looks like you've taken a wrong turn! This page must be hiding.",
+      "directions": "Let's find our way back together:",
+      "homepage": "Head to the Homepage",
+      "homepageHint": " - start a new adventure!",
+      "search": "Use the search bar above to find what you're looking for.",
+      "back": "Try going back to the previous page."
+    },
+    "serverError": {
+      "title": "Server Error",
+      "subtitle": "Something went wrong",
+      "intro": "We're sorry, something went wrong on our end. Please try again later.",
+      "documentTitle": "Server Error"
+    },
+    "admin": {
+      "title": "Admin",
+      "developerMode": "Developer Mode",
+      "developerModeMessage": "You are currently running in development mode, expect performance degradation",
+      "updateAvailable": "Update Available",
+      "currentVersion": "Current version: {current}",
+      "latestVersion": "Latest: {latest}",
+      "newFeatures": "New Features",
+      "fixes": "Fixes"
+    }
+  },
+  "errors": {
+    "header": "Error",
+    "fetchHeader": "Fetch Error",
+    "httpHeader": "HTTP error: {status}",
+    "invalidJson": "Invalid JSON",
+    "INTERNAL": "Internal Server Error",
+    "UNKNOWN": "An unknown error occurred",
+    "NO_PERMISSION": "You do not have permission to perform this action",
+    "NOT_LOGGED_IN": "You are not logged in",
+    "SERVER_NOT_FOUND": "Server not found",
+    "PLAYER_NOT_FOUND": "Player not found",
+    "ROLE_NOT_FOUND": "Role not found",
+    "REPORT_NOT_FOUND": "Report not found",
+    "APPEAL_NOT_FOUND": "Appeal not found",
+    "BAN_NOT_FOUND": "Ban not found",
+    "MUTE_NOT_FOUND": "Mute not found",
+    "WARNING_NOT_FOUND": "Warning not found",
+    "NOTE_NOT_FOUND": "Note not found",
+    "WEBHOOK_NOT_FOUND": "Webhook not found",
+    "RULE_NOT_FOUND": "Rule not found",
+    "DOCUMENT_NOT_FOUND": "Document not found",
+    "INVALID_INPUT": "Invalid input",
+    "INVALID_EMAIL": "Email address is invalid",
+    "INVALID_PASSWORD": "Password is invalid",
+    "INVALID_LOCALE": "Locale is not supported",
+    "EMAIL_IN_USE": "Email already in use",
+    "PASSWORD_BREACHED": "This password isn't safe to use as it's appeared in {count, plural, one {# known data breach} other {# known data breaches}}",
+    "PASSWORD_COMPROMISED": "This password isn't safe to use as it's appeared in {count, plural, one {# known data breach} other {# known data breaches}}",
+    "RATE_LIMIT": "Too many attempts. Please try again later.",
+    "DUPLICATE_APPEAL": "You already have an open appeal for this punishment",
+    "ALREADY_RESOLVED": "This has already been resolved",
+    "ALREADY_EXISTS": "This already exists",
+    "INVALID_NAME": "Name is invalid",
+    "INVALID_PIN": "Pin is invalid",
+    "INVALID_TARGET": "You cannot perform this action on yourself",
+    "INVALID_STATE": "Invalid state transition",
+    "INCORRECT_LOGIN": "Incorrect login details",
+    "REPORT_COMMENT_NOT_FOUND": "Report comment not found",
+    "APPEAL_COMMENT_NOT_FOUND": "Appeal comment not found",
+    "USER_NOT_FOUND": "User not found",
+    "NOTIFICATION_NOT_FOUND": "Notification not found",
+    "PUNISHMENT_NOT_FOUND": "Punishment not found",
+    "PUNISHMENT_NOT_ACTIVE": "This punishment is no longer active",
+    "REPORT_STATE_NOT_FOUND": "Report state not found",
+    "APPEAL_STATE_NOT_FOUND": "Appeal state not found",
+    "MUTE_RECORD_NOT_FOUND": "Mute record not found",
+    "BAN_RECORD_NOT_FOUND": "Ban record not found",
+    "KICK_NOT_FOUND": "Kick not found",
+    "INTERVAL_TOO_LARGE": "The requested interval is too large",
+    "LIMIT_TOO_LARGE": "The requested limit is too large",
+    "OFFSET_OUT_OF_RANGE": "Offset is greater than the available data",
+    "DB_CONNECTION_ERROR": "Could not connect to the database",
+    "MISSING_DATABASE_TABLES": "Required database tables are missing",
+    "CONSOLE_UUID_NOT_FOUND": "Console player not found",
+    "EXAMPLE_PAYLOAD_NOT_FOUND": "Example payload not found",
+    "CANNOT_DELETE_LAST_SERVER": "You cannot delete the last server",
+    "DEFAULT_ROLE_PROTECTED": "The default role cannot be modified",
+    "DEFAULT_ROLE_PARENT_FORBIDDEN": "The default role cannot be a parent",
+    "NO_ACCOUNT": "No account is associated with this email",
+    "SUBSCRIPTION_EXISTS": "Subscription already exists",
+    "SERVER_PERMISSION_DENIED": "You do not have access to this server"
+  },
+  "forms": {
+    "email": "Email address",
+    "password": "Password",
+    "currentPassword": "Current password",
+    "newPassword": "New password",
+    "confirmPassword": "Confirm Password",
+    "username": "Username",
+    "name": "Name",
+    "reason": "Reason",
+    "message": "Message",
+    "comment": "Add your comment here...",
+    "playerSelectorPlaceholder": "Search player",
+    "required": "This field is required",
+    "minLength": "Must be at least {n} characters",
+    "maxLength": "Must be at most {n} characters",
+    "passwordMismatch": "Passwords do not match"
+  },
+  "widgets": {
+    "select": {
+      "noOptions": "No options",
+      "noPlayersFound": "No players found",
+      "selectPlaceholder": "Select…",
+      "loading": "Loading…"
+    },
+    "languageSwitcher": {
+      "label": "Language",
+      "select": "Select language"
+    }
+  },
+  "components": {
+    "appealStep": {
+      "progress": "{step} of {total}",
+      "next": "Next: {next}"
+    }
+  },
+  "notifications": {
+    "appealCreated": "<b>{name}</b> created an appeal",
+    "appealCommentOwn": "<b>{name}</b> commented on your appeal",
+    "appealCommentOther": "<b>{name}</b> added a comment",
+    "appealAssignedOwn": "{actor} assigned <b>{assignee}</b> to review your appeal",
+    "appealAssignedOther": "<b>{actor}</b> assigned <b>{assignee}</b> to review appeal",
+    "appealStateOwn": "{actor} <b>{state}</b> your appeal",
+    "appealStateOther": "{actor} <b>{state}</b> appeal",
+    "reportCommentOwn": "{name} commented on your report",
+    "reportCommentOther": "<b>{name}</b> added a comment",
+    "reportAssignedOwn": "{actor} assigned <b>{assignee}</b> to review your report against {player}",
+    "reportAssignedOther": "<b>{actor}</b> assigned <b>{assignee}</b> to review report",
+    "reportStateOwn": "{actor} <b>{state}</b> your report",
+    "reportStateOther": "{actor} <b>{state}</b> report",
+    "stateLabels": {
+      "open": "opened",
+      "closed": "closed",
+      "approved": "approved",
+      "denied": "denied",
+      "resolved": "resolved",
+      "unresolved": "unresolved"
+    }
+  }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -122,6 +122,7 @@
     "INVALID_INPUT": "Invalid input",
     "INVALID_EMAIL": "Email address is invalid",
     "INVALID_PASSWORD": "Password is invalid",
+    "INVALID_PASSWORD_LENGTH": "Invalid password, minimum length {minLength} characters",
     "INVALID_LOCALE": "Locale is not supported",
     "EMAIL_IN_USE": "Email already in use",
     "PASSWORD_BREACHED": "This password isn't safe to use as it's appeared in {count, plural, one {# known data breach} other {# known data breaches}}",

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "nanoid": "3.3.11",
         "next": "14.2.35",
         "next-absolute-url": "1.2.2",
+        "next-intl": "^4.9.1",
         "next-seo": "6.8.0",
         "nextjs-url": "1.0.4",
         "opentype.js": "1.3.4",
@@ -1415,6 +1416,32 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
       "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.2.tgz",
+      "integrity": "sha512-vPnriihkfK0lzoQGaXq+qXH23VsYyansRTkTgo2aTG0k1NjLFyZimFVdfj4C9JkSE5dm7CEngcQ5TTc1yAyBfQ=="
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.4.tgz",
+      "integrity": "sha512-JVY39ROgLt+pIYngo6piyj4OVfZmXs/2FkC4wLS+ql1Eig/sGJKB7YwDO/5bkJFkfwaFAeIpgEiJc8hiYxNalw==",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.4"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.4.tgz",
+      "integrity": "sha512-8bSFZbrlvGX11ywMZxtgkPBt5Q8/etyts7j7j+GWpOVK1g43zwMIH3LZxk43HAtEP7L/jtZ+OZaMiFTOiBj9CA=="
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.3.tgz",
+      "integrity": "sha512-pHUjWb9NuhnMs8+PxQdzBtZRFJHlGhrURGAbm6Ltwl82BFajeuiIR3jblSa7ia3r62rXe/0YtVpUG3xWr5bFCA==",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.2"
+      }
     },
     "node_modules/@graphql-tools/merge": {
       "version": "8.4.2",
@@ -3457,6 +3484,303 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@phc/format": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
@@ -3943,6 +4267,11 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw=="
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3967,6 +4296,225 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@swc/core": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.26.tgz",
+      "integrity": "sha512-tglZGyx8N5PC+x1Nd/JrZxqpqlcZoSuG9gTDKO6AuFToFiVB3uS8HvbKFuO7g3lJzvFf9riAb94xs9HU2UhAHQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.26"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.26",
+        "@swc/core-darwin-x64": "1.15.26",
+        "@swc/core-linux-arm-gnueabihf": "1.15.26",
+        "@swc/core-linux-arm64-gnu": "1.15.26",
+        "@swc/core-linux-arm64-musl": "1.15.26",
+        "@swc/core-linux-ppc64-gnu": "1.15.26",
+        "@swc/core-linux-s390x-gnu": "1.15.26",
+        "@swc/core-linux-x64-gnu": "1.15.26",
+        "@swc/core-linux-x64-musl": "1.15.26",
+        "@swc/core-win32-arm64-msvc": "1.15.26",
+        "@swc/core-win32-ia32-msvc": "1.15.26",
+        "@swc/core-win32-x64-msvc": "1.15.26"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.26.tgz",
+      "integrity": "sha512-OmcP96CFsNOwa65tamQayRcfqhNlcQ3YCWOq+0Wb+CAM4uB7kOMrXY41Gj4atthxrGhLQ9pg7Vk26iApb88idA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.26.tgz",
+      "integrity": "sha512-liTTTpKSv89ivIxcZ+iU1cRige9Y7JkOjVnJ2Ystzl+DsWNHqt7wLTTgm/u7gEqmmAS2JKryODLQn3q1UtFNPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.26.tgz",
+      "integrity": "sha512-Y/g+m3I8CeBof5A3kWWOS6QA2HOIUytF5EeTgfwcAK+GKT/tGe7Xqo5svBtaqflU5od2zzbMTWqkinPXgRWGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.26.tgz",
+      "integrity": "sha512-19IvwyPfBN/rz9s7qXhOTQmW0922+pjpRUUvIebu+CMM75nX6YuDzHsGx8hSmn5dS89SNaMCh1lgUuXqm++6jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.26.tgz",
+      "integrity": "sha512-iNlbvTIo425rkKzDLLWFJGnFXr3myETUdIDHcjuiPNZE8b0ogmcAuilC4yEJX7FSHGbnlsoJcCT2xf4b3VJmmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.26.tgz",
+      "integrity": "sha512-AuuEOtG+YXKIjIUup4RsxYNklx6XVB3WKWfhxG6hnfPrn7vp89RNOLbbyyprgj6Sk7k9ulwGVTJElEvmBNPSCA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.26.tgz",
+      "integrity": "sha512-JcMDWQvW1BchUyRg8E0jHiTx7CQYpUr5uDEL1dnPDECrEjBEGG2ynmJ3XX70sWXql0JagqR1t3VpANYFWdUnqA==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.26.tgz",
+      "integrity": "sha512-FW7V7Mbpq4+PA7BiAq76LJs8MdNuUSylyuRVfQRkhIyeWadFroZ+KOPgjku8Z/fXzngxBRvsk+PGGB0t8mGcjA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.26.tgz",
+      "integrity": "sha512-w8erqMHsVcdGwUfJxF6LaiTuPoKnyLOcUbhLcxiXrlLt5MLjtlgcIeUY/NWK/oPoyqkgH+/i8pOJnMTxvl83ZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.26.tgz",
+      "integrity": "sha512-uDCWCNpUiqkbvPmsuPUTn/P7ag9SqNXD2JT/W3dUu7yZ2krzN+nmmoQ2xRX63/J6RYiHI7aT4jo7Z++lsljlPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.26.tgz",
+      "integrity": "sha512-2k1ax1QmmqLEnpC0uRCw7OXhBfyvdPqERBXupDasjYbChT6ZSO/uha28Bp38cw0viKIG79L27aTDkbkABsMW3w==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.26.tgz",
+      "integrity": "sha512-aUuYecSEGa4SUSdyCWaI/vk8jdseifYnsF1GZQx2+piL8GIuT/5QrVcFfmes4Iwy7FIVXxtzD063z/FfpZ7K7w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -3981,6 +4529,14 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@tanstack/react-virtual": {
@@ -9121,6 +9677,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/icu-minify": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.9.1.tgz",
+      "integrity": "sha512-6NkfF9GHHFouqnz+wuiLjCWQiyxoEyJ5liUv4Jxxo/8wyhV7MY0L0iTEGDAVEa4aAD58WqTxFMa20S5nyMjwNw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "^3.4.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -9337,6 +9907,15 @@
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.1.tgz",
+      "integrity": "sha512-1gAVEUt3wEPvTqML4Fsw9klZV5j0vszQxayP/fi6gUroAc8AUHiNaisBKLWxybL1AdWq1mP07YV1q8v4N92ilQ==",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.2",
+        "@formatjs/icu-messageformat-parser": "3.5.4"
       }
     },
     "node_modules/invariant": {
@@ -11720,6 +12299,49 @@
       "resolved": "https://registry.npmjs.org/next-absolute-url/-/next-absolute-url-1.2.2.tgz",
       "integrity": "sha512-Z2+LZXQTthhw2je9u4eq8QWXxXd57a6b54x9exBfQX4Dct6YxaMjcXZWNLHd9AOlCue84EsMpdSGP7wACqUnPg=="
     },
+    "node_modules/next-intl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.9.1.tgz",
+      "integrity": "sha512-N7ga0CjtYcdxNvaKNIi6eJ2mmatlHK5hp8rt0YO2Omoc1m0gean242/Ukdj6+gJNiReBVcYIjK0HZeNx7CV1ug==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.8.1",
+        "@parcel/watcher": "^2.4.1",
+        "@swc/core": "^1.15.2",
+        "icu-minify": "^4.9.1",
+        "negotiator": "^1.0.0",
+        "next-intl-swc-plugin-extractor": "^4.9.1",
+        "po-parser": "^2.1.1",
+        "use-intl": "^4.9.1"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl-swc-plugin-extractor": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.9.1.tgz",
+      "integrity": "sha512-8whJJ6oxJz8JqkHarggmmuEDyXgC7nEnaPhZD91CJwEWW4xp0AST3Mw17YxvHyP2vAF3taWfFbs1maD+WWtz3w=="
+    },
+    "node_modules/next-intl/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next-seo": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/next-seo/-/next-seo-6.8.0.tgz",
@@ -12828,6 +13450,11 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/po-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
+      "integrity": "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ=="
     },
     "node_modules/points": {
       "version": "3.2.0",
@@ -15883,6 +16510,26 @@
         "react": "*"
       }
     },
+    "node_modules/use-intl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.9.1.tgz",
+      "integrity": "sha512-iGVV/xFYlhe3btafRlL8RPLD2Jsuet4yqn9DR6LWWbMhULsJnXgLonDkzDmsAIBIwFtk02oJuX/Ox2vwHKF+UQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "dependencies": {
+        "@formatjs/fast-memoize": "^3.1.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "icu-minify": "^4.9.1",
+        "intl-messageformat": "^11.1.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/use-isomorphic-layout-effect": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz",
@@ -17475,6 +18122,32 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
       "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
     },
+    "@formatjs/fast-memoize": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.2.tgz",
+      "integrity": "sha512-vPnriihkfK0lzoQGaXq+qXH23VsYyansRTkTgo2aTG0k1NjLFyZimFVdfj4C9JkSE5dm7CEngcQ5TTc1yAyBfQ=="
+    },
+    "@formatjs/icu-messageformat-parser": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.4.tgz",
+      "integrity": "sha512-JVY39ROgLt+pIYngo6piyj4OVfZmXs/2FkC4wLS+ql1Eig/sGJKB7YwDO/5bkJFkfwaFAeIpgEiJc8hiYxNalw==",
+      "requires": {
+        "@formatjs/icu-skeleton-parser": "2.1.4"
+      }
+    },
+    "@formatjs/icu-skeleton-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.4.tgz",
+      "integrity": "sha512-8bSFZbrlvGX11ywMZxtgkPBt5Q8/etyts7j7j+GWpOVK1g43zwMIH3LZxk43HAtEP7L/jtZ+OZaMiFTOiBj9CA=="
+    },
+    "@formatjs/intl-localematcher": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.3.tgz",
+      "integrity": "sha512-pHUjWb9NuhnMs8+PxQdzBtZRFJHlGhrURGAbm6Ltwl82BFajeuiIR3jblSa7ia3r62rXe/0YtVpUG3xWr5bFCA==",
+      "requires": {
+        "@formatjs/fast-memoize": "3.1.2"
+      }
+    },
     "@graphql-tools/merge": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
@@ -18828,6 +19501,120 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "requires": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6",
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+          "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="
+        },
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="
+        }
+      }
+    },
+    "@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "optional": true
+    },
+    "@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "optional": true
+    },
+    "@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "optional": true
+    },
+    "@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "optional": true
+    },
+    "@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "optional": true
+    },
+    "@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "optional": true
+    },
+    "@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "optional": true
+    },
+    "@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "optional": true
+    },
+    "@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "optional": true
+    },
+    "@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "optional": true
+    },
+    "@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "optional": true
+    },
+    "@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "optional": true
+    },
+    "@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "optional": true
+    },
     "@phc/format": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
@@ -19175,6 +19962,11 @@
         "@rpldy/uploader": "1.13.0"
       }
     },
+    "@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw=="
+    },
     "@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -19199,6 +19991,99 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "@swc/core": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.26.tgz",
+      "integrity": "sha512-tglZGyx8N5PC+x1Nd/JrZxqpqlcZoSuG9gTDKO6AuFToFiVB3uS8HvbKFuO7g3lJzvFf9riAb94xs9HU2UhAHQ==",
+      "requires": {
+        "@swc/core-darwin-arm64": "1.15.26",
+        "@swc/core-darwin-x64": "1.15.26",
+        "@swc/core-linux-arm-gnueabihf": "1.15.26",
+        "@swc/core-linux-arm64-gnu": "1.15.26",
+        "@swc/core-linux-arm64-musl": "1.15.26",
+        "@swc/core-linux-ppc64-gnu": "1.15.26",
+        "@swc/core-linux-s390x-gnu": "1.15.26",
+        "@swc/core-linux-x64-gnu": "1.15.26",
+        "@swc/core-linux-x64-musl": "1.15.26",
+        "@swc/core-win32-arm64-msvc": "1.15.26",
+        "@swc/core-win32-ia32-msvc": "1.15.26",
+        "@swc/core-win32-x64-msvc": "1.15.26",
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.26"
+      }
+    },
+    "@swc/core-darwin-arm64": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.26.tgz",
+      "integrity": "sha512-OmcP96CFsNOwa65tamQayRcfqhNlcQ3YCWOq+0Wb+CAM4uB7kOMrXY41Gj4atthxrGhLQ9pg7Vk26iApb88idA==",
+      "optional": true
+    },
+    "@swc/core-darwin-x64": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.26.tgz",
+      "integrity": "sha512-liTTTpKSv89ivIxcZ+iU1cRige9Y7JkOjVnJ2Ystzl+DsWNHqt7wLTTgm/u7gEqmmAS2JKryODLQn3q1UtFNPQ==",
+      "optional": true
+    },
+    "@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.26.tgz",
+      "integrity": "sha512-Y/g+m3I8CeBof5A3kWWOS6QA2HOIUytF5EeTgfwcAK+GKT/tGe7Xqo5svBtaqflU5od2zzbMTWqkinPXgRWGgA==",
+      "optional": true
+    },
+    "@swc/core-linux-arm64-gnu": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.26.tgz",
+      "integrity": "sha512-19IvwyPfBN/rz9s7qXhOTQmW0922+pjpRUUvIebu+CMM75nX6YuDzHsGx8hSmn5dS89SNaMCh1lgUuXqm++6jg==",
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.26.tgz",
+      "integrity": "sha512-iNlbvTIo425rkKzDLLWFJGnFXr3myETUdIDHcjuiPNZE8b0ogmcAuilC4yEJX7FSHGbnlsoJcCT2xf4b3VJmmQ==",
+      "optional": true
+    },
+    "@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.26.tgz",
+      "integrity": "sha512-AuuEOtG+YXKIjIUup4RsxYNklx6XVB3WKWfhxG6hnfPrn7vp89RNOLbbyyprgj6Sk7k9ulwGVTJElEvmBNPSCA==",
+      "optional": true
+    },
+    "@swc/core-linux-s390x-gnu": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.26.tgz",
+      "integrity": "sha512-JcMDWQvW1BchUyRg8E0jHiTx7CQYpUr5uDEL1dnPDECrEjBEGG2ynmJ3XX70sWXql0JagqR1t3VpANYFWdUnqA==",
+      "optional": true
+    },
+    "@swc/core-linux-x64-gnu": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.26.tgz",
+      "integrity": "sha512-FW7V7Mbpq4+PA7BiAq76LJs8MdNuUSylyuRVfQRkhIyeWadFroZ+KOPgjku8Z/fXzngxBRvsk+PGGB0t8mGcjA==",
+      "optional": true
+    },
+    "@swc/core-linux-x64-musl": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.26.tgz",
+      "integrity": "sha512-w8erqMHsVcdGwUfJxF6LaiTuPoKnyLOcUbhLcxiXrlLt5MLjtlgcIeUY/NWK/oPoyqkgH+/i8pOJnMTxvl83ZQ==",
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.26.tgz",
+      "integrity": "sha512-uDCWCNpUiqkbvPmsuPUTn/P7ag9SqNXD2JT/W3dUu7yZ2krzN+nmmoQ2xRX63/J6RYiHI7aT4jo7Z++lsljlPA==",
+      "optional": true
+    },
+    "@swc/core-win32-ia32-msvc": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.26.tgz",
+      "integrity": "sha512-2k1ax1QmmqLEnpC0uRCw7OXhBfyvdPqERBXupDasjYbChT6ZSO/uha28Bp38cw0viKIG79L27aTDkbkABsMW3w==",
+      "optional": true
+    },
+    "@swc/core-win32-x64-msvc": {
+      "version": "1.15.26",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.26.tgz",
+      "integrity": "sha512-aUuYecSEGa4SUSdyCWaI/vk8jdseifYnsF1GZQx2+piL8GIuT/5QrVcFfmes4Iwy7FIVXxtzD063z/FfpZ7K7w==",
+      "optional": true
+    },
     "@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -19211,6 +20096,14 @@
       "requires": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "@swc/types": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "requires": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "@tanstack/react-virtual": {
@@ -23024,6 +23917,14 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "icu-minify": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.9.1.tgz",
+      "integrity": "sha512-6NkfF9GHHFouqnz+wuiLjCWQiyxoEyJ5liUv4Jxxo/8wyhV7MY0L0iTEGDAVEa4aAD58WqTxFMa20S5nyMjwNw==",
+      "requires": {
+        "@formatjs/icu-messageformat-parser": "^3.4.0"
+      }
+    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -23179,6 +24080,15 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
+    },
+    "intl-messageformat": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.1.tgz",
+      "integrity": "sha512-1gAVEUt3wEPvTqML4Fsw9klZV5j0vszQxayP/fi6gUroAc8AUHiNaisBKLWxybL1AdWq1mP07YV1q8v4N92ilQ==",
+      "requires": {
+        "@formatjs/fast-memoize": "3.1.2",
+        "@formatjs/icu-messageformat-parser": "3.5.4"
+      }
     },
     "invariant": {
       "version": "2.2.4",
@@ -24920,6 +25830,33 @@
       "resolved": "https://registry.npmjs.org/next-absolute-url/-/next-absolute-url-1.2.2.tgz",
       "integrity": "sha512-Z2+LZXQTthhw2je9u4eq8QWXxXd57a6b54x9exBfQX4Dct6YxaMjcXZWNLHd9AOlCue84EsMpdSGP7wACqUnPg=="
     },
+    "next-intl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.9.1.tgz",
+      "integrity": "sha512-N7ga0CjtYcdxNvaKNIi6eJ2mmatlHK5hp8rt0YO2Omoc1m0gean242/Ukdj6+gJNiReBVcYIjK0HZeNx7CV1ug==",
+      "requires": {
+        "@formatjs/intl-localematcher": "^0.8.1",
+        "@parcel/watcher": "^2.4.1",
+        "@swc/core": "^1.15.2",
+        "icu-minify": "^4.9.1",
+        "negotiator": "^1.0.0",
+        "next-intl-swc-plugin-extractor": "^4.9.1",
+        "po-parser": "^2.1.1",
+        "use-intl": "^4.9.1"
+      },
+      "dependencies": {
+        "negotiator": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+          "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
+        }
+      }
+    },
+    "next-intl-swc-plugin-extractor": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.9.1.tgz",
+      "integrity": "sha512-8whJJ6oxJz8JqkHarggmmuEDyXgC7nEnaPhZD91CJwEWW4xp0AST3Mw17YxvHyP2vAF3taWfFbs1maD+WWtz3w=="
+    },
     "next-seo": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/next-seo/-/next-seo-6.8.0.tgz",
@@ -25741,6 +26678,11 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
       "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+    },
+    "po-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
+      "integrity": "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ=="
     },
     "points": {
       "version": "3.2.0",
@@ -27840,6 +28782,17 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.0.tgz",
       "integrity": "sha512-lu87Za35V3n/MyMoEpD5zJv0k7hCn0p+V/fK2kWD+3k2u3kOCwO593UArbczg1fhfs2rqPEnHpULJ3KmGdDzvg=="
+    },
+    "use-intl": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.9.1.tgz",
+      "integrity": "sha512-iGVV/xFYlhe3btafRlL8RPLD2Jsuet4yqn9DR6LWWbMhULsJnXgLonDkzDmsAIBIwFtk02oJuX/Ox2vwHKF+UQ==",
+      "requires": {
+        "@formatjs/fast-memoize": "^3.1.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "icu-minify": "^4.9.1",
+        "intl-messageformat": "^11.1.0"
+      }
     },
     "use-isomorphic-layout-effect": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "nanoid": "3.3.11",
     "next": "14.2.35",
     "next-absolute-url": "1.2.2",
+    "next-intl": "^4.9.1",
     "next-seo": "6.8.0",
     "nextjs-url": "1.0.4",
     "opentype.js": "1.3.4",

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../components/DefaultLayout'
 import PageContainer from '../components/PageContainer'
 import PageHeader from '../components/PageHeader'
@@ -6,32 +7,29 @@ import Link from 'next/link'
 import Image from 'next/image'
 
 function Error () {
+  const t = useTranslations('pages.notFound')
+
   return (
-    <DefaultLayout title='Not Found'>
+    <DefaultLayout title={t('documentTitle')}>
       <PageContainer>
         <div className='flex flex-col-reverse md:flex-row items-center justify-center gap-10'>
           <div>
-            <Image src={(process.env.BASE_PATH || '') + '/images/error.png'} alt='Error' width='318' height='318' />
+            <Image src={(process.env.BASE_PATH || '') + '/images/error.png'} alt={t('subtitle')} width='318' height='318' />
           </div>
           <Panel className='md:border-0'>
-            <PageHeader subTitle='An error occurred' title='Oops! Page Not Found' />
+            <PageHeader subTitle={t('subtitle')} title={t('title')} />
             <div className='flex flex-col gap-4'>
-              <p>Looks like you&apos;ve taken a wrong turn! This page must be hiding.</p>
-              <h3 className='font-semibold'>Let&apos;s find our way back together:</h3>
+              <p>{t('intro')}</p>
+              <h3 className='font-semibold'>{t('directions')}</h3>
               <ol className='list-disc pl-3'>
                 <li>
-                  <Link href='/' className='text-accent-500'>Head to the Homepage</Link> - start a new adventure!
+                  <Link href='/' className='text-accent-500'>{t('homepage')}</Link>{t('homepageHint')}
                 </li>
                 <li>
-                  Use the Search Bar - it&apos;s like a treasure map!
+                  {t('search')}
                 </li>
-                <li>Check the URL - maybe there&apos;s a tiny typo.</li>
+                <li>{t('back')}</li>
               </ol>
-            </div>
-            <div className='mt-6 flex flex-col gap-2 italic text-gray-300'>
-              <p>Whilst you&apos;re here, enjoy this joke:</p>
-              <p><strong>Why don&apos;t Minecraft players ever get lost?</strong></p>
-              <p>Because they always know their coordinates!</p>
             </div>
           </Panel>
         </div>

--- a/pages/500.js
+++ b/pages/500.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../components/DefaultLayout'
 import PageContainer from '../components/PageContainer'
 import PageHeader from '../components/PageHeader'
@@ -6,32 +7,26 @@ import Link from 'next/link'
 import Image from 'next/image'
 
 function Error () {
+  const t = useTranslations('pages.serverError')
+  const tNotFound = useTranslations('pages.notFound')
+
   return (
-    <DefaultLayout title='Error'>
+    <DefaultLayout title={t('documentTitle')}>
       <PageContainer>
         <div className='flex flex-col-reverse md:flex-row items-center justify-center gap-10'>
           <div>
-            <Image src={(process.env.BASE_PATH || '') + '/images/error.png'} alt='Error' width='318' height='318' />
+            <Image src={(process.env.BASE_PATH || '') + '/images/error.png'} alt={t('title')} width='318' height='318' />
           </div>
           <Panel className='md:border-0'>
-            <PageHeader subTitle='Oops!' title='Something went wrong' />
+            <PageHeader subTitle={t('subtitle')} title={t('title')} />
             <div className='flex flex-col gap-4'>
-              <p>The server is having a breakdown, but our team of creepers are on it!</p>
-              <h3 className='font-semibold'>In the mean time, you can:</h3>
+              <p>{t('intro')}</p>
+              <h3 className='font-semibold'>{tNotFound('directions')}</h3>
               <ol className='list-disc pl-3'>
                 <li>
-                  <Link href='/' className='text-accent-500'>Head to the Homepage</Link> - try a new adventure!
+                  <Link href='/' className='text-accent-500'>{tNotFound('homepage')}</Link>{tNotFound('homepageHint')}
                 </li>
-                <li>
-                  Use the Search Bar - it&apos;s like a treasure map!
-                </li>
-                <li>Check back later - The server might just need a little break.</li>
               </ol>
-            </div>
-            <div className='mt-6 flex flex-col gap-2 italic text-gray-300'>
-              <p>Whilst you&apos;re here, enjoy this joke:</p>
-              <p><strong>Why did the Minecraft server break?</strong></p>
-              <p>Because it couldn&apos;t handle all the blocks!!</p>
             </div>
           </Panel>
         </div>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,68 @@
 import Head from 'next/head'
 import { DefaultSeo } from 'next-seo'
+import { NextIntlClientProvider } from 'next-intl'
+import { useEffect, useState } from 'react'
 
 import '../styles/index.css'
-import { useEffect } from 'react'
+import enMessages from '../messages/en.json'
+import { DEFAULT_LOCALE, LOCALE_CONFIG, useResolvedLocale } from '../utils/locale'
 
-function MyApp ({ Component, pageProps, graphql }) {
+const PRELOADED_MESSAGES = { en: enMessages }
+const isDev = process.env.NODE_ENV !== 'production'
+
+const isPlainObject = (value) =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+
+const mergeFallback = (fallback, override) => {
+  if (!isPlainObject(fallback)) return override
+  if (!isPlainObject(override)) return override !== undefined ? override : fallback
+
+  const result = { ...fallback }
+
+  for (const key of Object.keys(override)) {
+    result[key] = mergeFallback(fallback[key], override[key])
+  }
+
+  return result
+}
+
+const lookupFallback = (key) => {
+  const segments = key.split('.')
+  let cursor = enMessages
+
+  for (const segment of segments) {
+    if (cursor == null || typeof cursor !== 'object') return null
+
+    cursor = cursor[segment]
+  }
+
+  return typeof cursor === 'string' ? cursor : null
+}
+
+const intlOnError = (error) => {
+  if (error?.code === 'MISSING_MESSAGE') {
+    if (isDev) console.warn(`[i18n] Missing translation, falling back to en: ${error.message}`)
+
+    return
+  }
+
+  if (isDev) console.error(error)
+}
+
+const intlGetMessageFallback = ({ key, namespace }) => {
+  const fullKey = namespace ? `${namespace}.${key}` : key
+  const enValue = lookupFallback(fullKey)
+
+  if (enValue) return enValue
+
+  return isDev ? `[${fullKey}]` : ''
+}
+
+function MyApp ({ Component, pageProps }) {
+  const { locale } = useResolvedLocale()
+  const [messages, setMessages] = useState(enMessages)
+  const [activeLocale, setActiveLocale] = useState(DEFAULT_LOCALE)
+
   useEffect(() => {
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker
@@ -15,21 +73,70 @@ function MyApp ({ Component, pageProps, graphql }) {
     }
   }, [])
 
+  useEffect(() => {
+    let cancelled = false
+
+    const apply = async () => {
+      if (locale === activeLocale) return
+
+      if (PRELOADED_MESSAGES[locale]) {
+        setMessages(mergeFallback(enMessages, PRELOADED_MESSAGES[locale]))
+        setActiveLocale(locale)
+        return
+      }
+
+      try {
+        const mod = await import(`../messages/${locale}.json`)
+
+        if (cancelled) return
+
+        PRELOADED_MESSAGES[locale] = mod.default || mod
+        setMessages(mergeFallback(enMessages, PRELOADED_MESSAGES[locale]))
+        setActiveLocale(locale)
+      } catch (err) {
+        console.error(`Failed to load messages for locale "${locale}"`, err)
+      }
+    }
+
+    apply()
+
+    return () => {
+      cancelled = true
+    }
+  }, [locale, activeLocale])
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+
+    const htmlLang = LOCALE_CONFIG[activeLocale]?.htmlLang || LOCALE_CONFIG[DEFAULT_LOCALE].htmlLang
+
+    if (document.documentElement.lang !== htmlLang) {
+      document.documentElement.lang = htmlLang
+    }
+  }, [activeLocale])
+
+  const ogLocale = LOCALE_CONFIG[activeLocale]?.openGraphLocale || LOCALE_CONFIG[DEFAULT_LOCALE].openGraphLocale
+
   return (
-    <>
+    <NextIntlClientProvider
+      locale={activeLocale}
+      messages={messages}
+      onError={intlOnError}
+      getMessageFallback={intlGetMessageFallback}
+    >
       <Head>
         <meta name='viewport' content='initial-scale=1.0, width=device-width' />
       </Head>
       <DefaultSeo
         openGraph={{
           type: 'website',
-          locale: 'en_UK',
+          locale: ogLocale,
           url: pageProps.origin,
           site_name: 'Ban Management'
         }}
       />
       <Component {...pageProps} />
-    </>
+    </NextIntlClientProvider>
   )
 }
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,14 +1,27 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 import resolveConfig from 'tailwindcss/resolveConfig'
 import tailwindConfig from '../tailwind.config'
+import { LOCALE_CONFIG, DEFAULT_LOCALE, negotiateLocaleFromRequest } from '../utils/locale'
 
 const fullConfig = resolveConfig(tailwindConfig)
 
 export default class MyDocument extends Document {
+  static async getInitialProps (ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    const locale = ctx.req
+      ? negotiateLocaleFromRequest(ctx.req)
+      : DEFAULT_LOCALE
+
+    return { ...initialProps, locale }
+  }
+
   render () {
+    const locale = this.props.locale || DEFAULT_LOCALE
+    const htmlLang = LOCALE_CONFIG[locale]?.htmlLang || LOCALE_CONFIG[DEFAULT_LOCALE].htmlLang
+
     return (
       // Avoid FOUC by setting a background color that matches the theme
-      <Html lang='en' style={{ background: fullConfig.theme.colors.primary['500'] }}>
+      <Html lang={htmlLang} style={{ background: fullConfig.theme.colors.primary['500'] }}>
         <Head>
           <meta charSet='utf-8' />
           <meta name='author' content='BanManager-WebUI' />

--- a/pages/account/index.js
+++ b/pages/account/index.js
@@ -1,5 +1,6 @@
 import { FaPencilAlt } from 'react-icons/fa'
 import { MdLock, MdOutlineEmail } from 'react-icons/md'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../components/DefaultLayout'
 import PageContainer from '../../components/PageContainer'
 import Avatar from '../../components/Avatar'
@@ -9,13 +10,14 @@ import PageHeader from '../../components/PageHeader'
 import Dropdown from '../../components/Dropdown'
 
 export default function Page () {
+  const t = useTranslations('pages.account')
   const { user } = useUser({ redirectTo: '/login' })
 
   return (
-    <DefaultLayout title='Account' loading={!user}>
+    <DefaultLayout title={t('documentTitle')} loading={!user}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader subTitle='Account' title={user?.name} />
+          <PageHeader subTitle={t('subtitle')} title={user?.name} />
           <div className='mx-auto mb-6'>
             <Avatar uuid={user?.id} height='64' width='64' />
           </div>
@@ -27,18 +29,22 @@ export default function Page () {
 }
 
 const UnregisteredAccountMenu = () => {
+  const t = useTranslations('pages.account')
+
   return (
     <div className='flex flex-col'>
-      <Dropdown.Item name='Register' className='rounded-t-3xl' href='/account/register' icon={<FaPencilAlt />} />
+      <Dropdown.Item name={t('register')} className='rounded-t-3xl' href='/account/register' icon={<FaPencilAlt />} />
     </div>
   )
 }
 
 const RegisteredAccountMenu = ({ email }) => {
+  const t = useTranslations('pages.account')
+
   return (
     <div className='flex flex-col divide-y divide-primary-400'>
-      <Dropdown.Item name={email || 'Email'} className='rounded-t-3xl' href='/account/email' icon={<MdOutlineEmail />} />
-      <Dropdown.Item name='Password' className='rounded-b-3xl' href='/account/password' icon={<MdLock />} />
+      <Dropdown.Item name={email || t('email')} className='rounded-t-3xl' href='/account/email' icon={<MdOutlineEmail />} />
+      <Dropdown.Item name={t('password')} className='rounded-b-3xl' href='/account/password' icon={<MdLock />} />
     </div>
   )
 }

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -1,5 +1,6 @@
 import { AiOutlinePlus } from 'react-icons/ai'
 import { TiTick } from 'react-icons/ti'
+import { useTranslations } from 'next-intl'
 import { upperFirst } from 'lodash-es'
 import Message from '../../components/Message'
 import AdminLayout from '../../components/AdminLayout'
@@ -45,6 +46,7 @@ const formatCommitMessage = (message) => upperFirst(
 )
 
 function Page ({ latestVersion, version, newFeatures, fixes }) {
+  const t = useTranslations('pages.admin')
   const features = newFeatures?.map(item => (
     <Message.Item key={item.sha}>
       <AiOutlinePlus className='text-xl inline' /> {formatCommitMessage(item.commit.message)}
@@ -57,27 +59,30 @@ function Page ({ latestVersion, version, newFeatures, fixes }) {
   ))
 
   return (
-    <AdminLayout title='Admin'>
+    <AdminLayout title={t('title')}>
       {process.env.IS_DEV === 'true' &&
         <Message warning>
-          <Message.Header>Developer Mode</Message.Header>
+          <Message.Header>{t('developerMode')}</Message.Header>
           <Message.List>
-            <Message.Item>You are currently running in development mode, expect performance degradation</Message.Item>
+            <Message.Item>{t('developerModeMessage')}</Message.Item>
           </Message.List>
         </Message>}
       {version !== latestVersion &&
         <Message info>
-          <Message.Header>Update Available</Message.Header>
+          <Message.Header>{t('updateAvailable')}</Message.Header>
           <Message.List>
-            <Message.Item>Current version: {version.slice(0, 7)}<br />Latest: {latestVersion.slice(0, 7)}</Message.Item>
+            <Message.Item>
+              {t('currentVersion', { current: version.slice(0, 7) })}<br />
+              {t('latestVersion', { latest: latestVersion.slice(0, 7) })}
+            </Message.Item>
             {!!newFeatures?.length &&
               <>
-                <Message.Item className='font-bold text-sm'>New Features</Message.Item>
+                <Message.Item className='font-bold text-sm'>{t('newFeatures')}</Message.Item>
                 {features}
               </>}
             {!!fixes?.length &&
               <>
-                <Message.Item className='font-bold text-sm'>Fixes</Message.Item>
+                <Message.Item className='font-bold text-sm'>{t('fixes')}</Message.Item>
                 {bugFixes}
               </>}
           </Message.List>

--- a/pages/appeal/index.js
+++ b/pages/appeal/index.js
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import Button from '../../components/Button'
 import DefaultLayout from '../../components/DefaultLayout'
 import PageContainer from '../../components/PageContainer'
@@ -8,34 +9,40 @@ import { MdOutlineEmail, MdPin } from 'react-icons/md'
 import { useUser } from '../../utils'
 
 function Page () {
+  const t = useTranslations('pages.appeal')
+
   useUser({ redirectIfFound: true, redirectTo: '/appeal/punishment' })
 
   return (
-    <DefaultLayout title='Appeal'>
+    <DefaultLayout title={t('documentTitle')}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <AppealStepHeader step={1} title='Pin Login' nextStep='Select Punishment' />
-          <p className='mb-6'>First, we need to know who you are.</p>
+          <AppealStepHeader step={1} title={t('stepHeader.step1')} nextStep={t('stepHeader.selectPunishment')} />
+          <p className='mb-6'>{t('intro')}</p>
           <Link href='/appeal/pin'>
             <div className='flex gap-4'>
               <Button className='w-12 h-12'><MdPin /></Button>
               <div>
-                <p className='underline'>I have a 6 digit pin, e.g. <code>123456</code></p>
-                <p className='text-sm text-gray-400'>This can be found when you join the Minecraft server, either on the ban screen or by using the <code className='bg-primary-900'>/bmpin</code> command.</p>
-                <p className='text-sm text-gray-400 mt-2'>Note: this pin expires after 5 minutes.</p>
+                <p className='underline'>{t('pinHelp')}<code>123456</code></p>
+                <p className='text-sm text-gray-400'>
+                  {t.rich('pinDescription', {
+                    command: () => <code className='bg-primary-900'>/bmpin</code>
+                  })}
+                </p>
+                <p className='text-sm text-gray-400 mt-2'>{t('pinExpiry')}</p>
               </div>
             </div>
           </Link>
           <div className='inline-flex items-center justify-center w-full'>
             <hr className='w-full h-px my-8 bg-primary-900 border-0 ' />
-            <span className='absolute px-3 font-medium bg-primary-500 -translate-x-1/2  left-1/2'>OR</span>
+            <span className='absolute px-3 font-medium bg-primary-500 -translate-x-1/2  left-1/2'>{t('or')}</span>
           </div>
           <Link href='/appeal/account'>
             <div className='flex gap-4'>
               <Button className='w-12 h-12'><MdOutlineEmail /></Button>
               <div>
-                <p className='underline'>I already have an account</p>
-                <p className='text-sm text-gray-400'>This is specific for this website and NOT your Microsoft/Mojang credentials.</p>
+                <p className='underline'>{t('haveAccount')}</p>
+                <p className='text-sm text-gray-400'>{t('haveAccountDescription')}</p>
               </div>
             </div>
           </Link>

--- a/pages/forgotten-password.js
+++ b/pages/forgotten-password.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../components/DefaultLayout'
 import PageContainer from '../components/PageContainer'
 import PlayerLoginPinForm from '../components/PlayerLoginPinForm'
@@ -8,6 +9,7 @@ import Panel from '../components/Panel'
 
 function Page () {
   const router = useRouter()
+  const t = useTranslations('pages.forgottenPassword')
   const { user } = useUser({ redirectIfFound: true, redirectTo: '/dashboard' })
   const onSuccess = ({ responseData }) => {
     if (responseData.hasAccount) return router.push('/account/password')
@@ -16,10 +18,10 @@ function Page () {
   }
 
   return (
-    <DefaultLayout title='Forgotten Password' loading={user}>
+    <DefaultLayout title={t('title')} loading={user}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader title='Forgotten Password' subTitle='Help' />
+          <PageHeader title={t('title')} subTitle={t('subtitle')} />
           <PlayerLoginPinForm onSuccess={onSuccess} showHint />
         </Panel>
       </PageContainer>

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../components/DefaultLayout'
 import PageContainer from '../components/PageContainer'
 import PlayerLoginPasswordForm from '../components/PlayerLoginPasswordForm'
@@ -8,16 +9,17 @@ import { useUser } from '../utils'
 
 function Page () {
   const router = useRouter()
+  const t = useTranslations('pages.login')
   const { user } = useUser({ redirectIfFound: true, redirectTo: '/dashboard' })
   const onSuccess = () => {
     router.push('/dashboard')
   }
 
   return (
-    <DefaultLayout title='Login' loading={user}>
+    <DefaultLayout title={t('title')} loading={user}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader title='Login' subTitle='Welcome back' />
+          <PageHeader title={t('title')} subTitle={t('subtitle')} />
           <PlayerLoginPasswordForm onSuccess={onSuccess} showForgotPassword />
         </Panel>
       </PageContainer>

--- a/server/app.js
+++ b/server/app.js
@@ -69,8 +69,12 @@ module.exports = async function ({ dbPool, logger, serversPool, disableUI = fals
     } catch (err) {
       ctx.log.error(err)
 
+      const exposed = err.exposed || err.expose
+
       ctx.status = err.status || 500
-      ctx.body = { error: (err.exposed || err.expose) ? err.message : 'Internal Server Error' }
+      ctx.body = exposed
+        ? { error: err.message, code: err.code || 'UNKNOWN', ...(err.meta ? { meta: err.meta } : {}) }
+        : { error: 'Internal Server Error', code: 'INTERNAL' }
       ctx.app.emit('error', err, ctx)
     }
   })
@@ -162,7 +166,7 @@ module.exports = async function ({ dbPool, logger, serversPool, disableUI = fals
   server.use(async (ctx) => {
     if (ctx.status === 404) {
       ctx.status = 404
-      ctx.body = { error: 'Not Found' }
+      ctx.body = { error: 'Not Found', code: 'NOT_FOUND' }
     }
   })
 

--- a/server/data/error-translation.js
+++ b/server/data/error-translation.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const NON_TRANSLATABLE_APP_CODES = new Set([
+  'INTERNAL_SERVER_ERROR',
+  'INTERNAL',
+  'BAD_USER_INPUT',
+  'UNKNOWN'
+])
+
+const translateRestError = (t, responseData) => {
+  if (!responseData) return null
+
+  const code = responseData.code
+  const meta = responseData.meta || {}
+  const translated = code && t.has(`errors.${code}`) ? t(`errors.${code}`, meta) : null
+  const err = new Error(translated || responseData.error || 'Unknown error')
+
+  err.code = code
+  err.meta = meta
+
+  return err
+}
+
+const translateGraphqlError = (t, source) => {
+  if (!source) return source
+
+  const transportCode = source.extensions?.code || source.code
+  const appCode = source.extensions?.appCode || (transportCode === 'ERR_EXPOSED' ? null : transportCode)
+  const meta = source.extensions?.meta || source.meta || {}
+
+  if (appCode && !NON_TRANSLATABLE_APP_CODES.has(appCode)) {
+    const translated = t.has(`errors.${appCode}`) ? t(`errors.${appCode}`, meta) : null
+
+    if (translated) return translated
+  }
+
+  return source.message || source
+}
+
+module.exports = {
+  NON_TRANSLATABLE_APP_CODES,
+  translateRestError,
+  translateGraphqlError
+}

--- a/server/data/exposed-error.js
+++ b/server/data/exposed-error.js
@@ -1,12 +1,15 @@
-module.exports = function ExposedError (message, code) {
+module.exports = function ExposedError (message, code, meta) {
   Error.captureStackTrace(this, this.constructor)
 
   this.name = this.constructor.name
   this.message = message
-  this.code = code
+  this.code = code || 'UNKNOWN'
+  this.meta = meta || null
   this.exposed = true
   this.extensions = {
-    code: 'ERR_EXPOSED'
+    code: 'ERR_EXPOSED',
+    appCode: this.code,
+    ...(this.meta ? { meta: this.meta } : {})
   }
 }
 

--- a/server/data/locales.js
+++ b/server/data/locales.js
@@ -1,0 +1,81 @@
+const SUPPORTED_LOCALES = ['en', 'de']
+const DEFAULT_LOCALE = 'en'
+const LOCALE_COOKIE = 'bm_locale'
+
+const isSupportedLocale = (value) =>
+  typeof value === 'string' && SUPPORTED_LOCALES.includes(value)
+
+const parseCookieHeader = (cookieHeader, name) => {
+  if (!cookieHeader || typeof cookieHeader !== 'string') return null
+
+  const parts = cookieHeader.split(';')
+
+  for (const part of parts) {
+    const trimmed = part.trim()
+    const eq = trimmed.indexOf('=')
+
+    if (eq === -1) continue
+
+    const key = trimmed.slice(0, eq).trim()
+
+    if (key !== name) continue
+
+    return decodeURIComponent(trimmed.slice(eq + 1).trim())
+  }
+
+  return null
+}
+
+const parseAcceptLanguage = (header) => {
+  if (!header || typeof header !== 'string') return []
+
+  return header
+    .split(',')
+    .map((entry) => {
+      const [tag, ...params] = entry.split(';').map((p) => p.trim())
+      const qParam = params.find((p) => p.startsWith('q='))
+      const q = qParam ? parseFloat(qParam.slice(2)) : 1.0
+
+      return { tag, q: Number.isFinite(q) ? q : 1.0 }
+    })
+    .filter((entry) => entry.tag)
+    .sort((a, b) => b.q - a.q)
+    .map((entry) => entry.tag.toLowerCase())
+}
+
+const negotiateLocale = ({ user, cookieValue, acceptLanguage } = {}) => {
+  if (user && isSupportedLocale(user.locale)) return user.locale
+  if (isSupportedLocale(cookieValue)) return cookieValue
+
+  const ranked = parseAcceptLanguage(acceptLanguage)
+
+  for (const tag of ranked) {
+    const primary = tag.split('-')[0]
+
+    if (isSupportedLocale(primary)) return primary
+  }
+
+  return DEFAULT_LOCALE
+}
+
+const negotiateLocaleFromRequest = (req, user) => {
+  const cookieHeader = req && req.headers && req.headers.cookie ? req.headers.cookie : ''
+  const acceptLanguage = req && req.headers && req.headers['accept-language'] ? req.headers['accept-language'] : ''
+
+  return negotiateLocale({
+    user,
+    cookieValue: parseCookieHeader(cookieHeader, LOCALE_COOKIE),
+    acceptLanguage
+  })
+}
+
+module.exports = {
+  SUPPORTED_LOCALES,
+  DEFAULT_LOCALE,
+  LOCALE_COOKIE,
+  isSupportedLocale,
+  parseCookieHeader,
+  parseAcceptLanguage,
+  negotiateLocale,
+  negotiateLocaleFromRequest
+}

--- a/server/data/migrations/20260418194007-user-locale.js
+++ b/server/data/migrations/20260418194007-user-locale.js
@@ -1,0 +1,11 @@
+exports.up = async function (db) {
+  await db.addColumn('bm_web_users', 'locale', { type: 'string', length: 10, notNull: false, defaultValue: null })
+}
+
+exports.down = async function (db) {
+  await db.removeColumn('bm_web_users', 'locale')
+}
+
+exports._meta = {
+  version: 1
+}

--- a/server/data/webhook/index.js
+++ b/server/data/webhook/index.js
@@ -76,7 +76,7 @@ const generateExamplePayload = async (session, state, type) => {
   const examplePayload = examplePayloads[type]
 
   if (!examplePayload) {
-    throw new ExposedError(`No example payload found for type ${type}`)
+    throw new ExposedError(`No example payload found for type ${type}`, 'EXAMPLE_PAYLOAD_NOT_FOUND')
   }
 
   if (examplePayload.actorId) {

--- a/server/graphql/directives/allow-if-logged-in.js
+++ b/server/graphql/directives/allow-if-logged-in.js
@@ -15,8 +15,7 @@ function allowIfLoggedInDirective () {
           const { session } = args[2]
 
           if (!valid(session)) {
-            throw new ExposedError(
-              'You do not have permission to perform this action, please contact your server administrator')
+            throw new ExposedError('You are not logged in', 'NOT_LOGGED_IN')
           }
 
           return resolve.apply(this, args)

--- a/server/graphql/directives/allow-if.js
+++ b/server/graphql/directives/allow-if.js
@@ -39,7 +39,8 @@ function allowIfDirective () {
               !isNullableType(info.returnType) // Cover non-nullable fields
             ) {
               throw new ExposedError(
-                'You do not have permission to perform this action, please contact your server administrator')
+                'You do not have permission to perform this action, please contact your server administrator',
+                'NO_PERMISSION')
             }
 
             // @TODO Test more

--- a/server/graphql/resolvers/mutations/appeal-state.js
+++ b/server/graphql/resolvers/mutations/appeal-state.js
@@ -6,19 +6,19 @@ const { subscribeAppeal, notifyAppeal } = require('../../../data/notification/ap
 module.exports = async function appealState (obj, { state: stateId, id }, { session, state }, info) {
   const [data] = await state.dbPool('bm_web_appeals').where({ id })
 
-  if (!data) throw new ExposedError(`Appeal ${id} does not exist`)
+  if (!data) throw new ExposedError(`Appeal ${id} does not exist`, 'APPEAL_NOT_FOUND')
 
   const canUpdate = state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.any') ||
     (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.own') && state.acl.owns(data.actor_id)) ||
     (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.assigned') && state.acl.owns(data.assignee_id))
 
   if (!canUpdate) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   const row = await state.dbPool('bm_web_appeal_states').where('id', stateId).first()
 
-  if (!row) throw new ExposedError(`Appeal State ${stateId} does not exist`)
+  if (!row) throw new ExposedError(`Appeal State ${stateId} does not exist`, 'APPEAL_STATE_NOT_FOUND')
 
   let commentId
 

--- a/server/graphql/resolvers/mutations/appeal-subscription-state.js
+++ b/server/graphql/resolvers/mutations/appeal-subscription-state.js
@@ -6,13 +6,13 @@ module.exports = async function appealSubscriptionState (obj, { id, subscription
     .where({ id })
     .first()
 
-  if (!data) throw new ExposedError(`Appeal ${id} does not exist`)
+  if (!data) throw new ExposedError(`Appeal ${id} does not exist`, 'APPEAL_NOT_FOUND')
 
   const canView = state.acl.hasServerPermission(data.server_id, 'player.appeals', 'view.any') ||
     (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'view.own') && state.acl.owns(data.actor_id)) ||
     (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'view.assigned') && state.acl.owns(data.assignee_id))
 
-  if (!canView) throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+  if (!canView) throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
 
   if (subscriptionState === 'SUBSCRIBED') {
     await subscribeAppeal(state.dbPool, id, session.playerId)

--- a/server/graphql/resolvers/mutations/assign-appeal.js
+++ b/server/graphql/resolvers/mutations/assign-appeal.js
@@ -9,25 +9,25 @@ module.exports = async function assignAppeal (obj, { player, id }, { session, st
     .where({ id })
     .first()
 
-  if (!data) throw new ExposedError(`Appeal ${id} does not exist`)
+  if (!data) throw new ExposedError(`Appeal ${id} does not exist`, 'APPEAL_NOT_FOUND')
 
   const hasPermission = state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.assign.any') ||
       (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.assign.own') && state.acl.owns(data.actor_id)) ||
       (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.assign.assigned') && state.acl.owns(data.assignee_id))
 
-  if (!hasPermission) throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
-  if (data.actor_id.equals(player)) throw new ExposedError('You cannot assign an appeal to the player which created it')
+  if (!hasPermission) throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
+  if (data.actor_id.equals(player)) throw new ExposedError('You cannot assign an appeal to the player which created it', 'INVALID_TARGET')
 
   const server = state.serversPool.get(data.server_id)
 
-  if (!server) throw new ExposedError(`Server ${data.server_id} does not exist`)
+  if (!server) throw new ExposedError(`Server ${data.server_id} does not exist`, 'SERVER_NOT_FOUND')
 
   const playerData = await server.pool(server.config.tables.players)
     .select('id')
     .where('id', player)
     .first()
 
-  if (!playerData) throw new ExposedError(`Player ${unparse(player)} does not exist`)
+  if (!playerData) throw new ExposedError(`Player ${unparse(player)} does not exist`, 'PLAYER_NOT_FOUND')
 
   let commentId
 

--- a/server/graphql/resolvers/mutations/assign-report.js
+++ b/server/graphql/resolvers/mutations/assign-report.js
@@ -7,28 +7,28 @@ const { subscribeReport, notifyReport } = require('../../../data/notification/re
 module.exports = async function assignReport (obj, { serverId, player, report: id }, { session, state }, info) {
   const server = state.serversPool.get(serverId)
 
-  if (!server) throw new ExposedError(`Server ${serverId} does not exist`)
+  if (!server) throw new ExposedError(`Server ${serverId} does not exist`, 'SERVER_NOT_FOUND')
 
   const data = await server.pool(server.config.tables.playerReports)
     .where({ id })
     .first()
 
-  if (!data) throw new ExposedError(`Report ${id} does not exist`)
+  if (!data) throw new ExposedError(`Report ${id} does not exist`, 'REPORT_NOT_FOUND')
 
   const hasPermission = state.acl.hasServerPermission(serverId, 'player.reports', 'update.assign.any') ||
       (state.acl.hasServerPermission(serverId, 'player.reports', 'update.assign.own') && state.acl.owns(data.actor_id)) ||
       (state.acl.hasServerPermission(serverId, 'player.reports', 'update.assign.assigned') && state.acl.owns(data.assignee_id)) ||
       (state.acl.hasServerPermission(serverId, 'player.reports', 'update.assign.reported') && state.acl.owns(data.player_id))
 
-  if (!hasPermission) throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
-  if (data.actor_id.equals(player)) throw new ExposedError('You cannot assign a report to the player which created it')
+  if (!hasPermission) throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
+  if (data.actor_id.equals(player)) throw new ExposedError('You cannot assign a report to the player which created it', 'INVALID_TARGET')
 
   const playerData = await server.pool(server.config.tables.players)
     .select('id')
     .where('id', player)
     .first()
 
-  if (!playerData) throw new ExposedError(`Player ${unparse(player)} does not exist`)
+  if (!playerData) throw new ExposedError(`Player ${unparse(player)} does not exist`, 'PLAYER_NOT_FOUND')
 
   await server.pool(server.config.tables.playerReports)
     .update({

--- a/server/graphql/resolvers/mutations/assign-role.js
+++ b/server/graphql/resolvers/mutations/assign-role.js
@@ -15,7 +15,7 @@ module.exports = async function assignRole (obj, { players, role: id }, { state 
   }, fields, 'roles').where('role_id', id)
   const [role] = await query.exec()
 
-  if (!role) throw new ExposedError(`Role ${id} does not exist`)
+  if (!role) throw new ExposedError(`Role ${id} does not exist`, 'ROLE_NOT_FOUND')
 
   // Ensure they exist in bm_web_users
   await state.dbPool('bm_web_users')

--- a/server/graphql/resolvers/mutations/assign-server-role.js
+++ b/server/graphql/resolvers/mutations/assign-server-role.js
@@ -4,7 +4,7 @@ const { getSql } = require('../../utils')
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function assignServerRole (obj, { players, role: id, serverId }, { state }, info) {
-  if (!state.serversPool.get(serverId)) throw new ExposedError(`Server ${serverId} does not exist`)
+  if (!state.serversPool.get(serverId)) throw new ExposedError(`Server ${serverId} does not exist`, 'SERVER_NOT_FOUND')
 
   const fields = parseResolveInfo(info)
   const query = getSql(info.schema, {
@@ -17,7 +17,7 @@ module.exports = async function assignServerRole (obj, { players, role: id, serv
   }, fields, 'roles').where('role_id', id)
   const [role] = await query.exec()
 
-  if (!role) throw new ExposedError(`Role ${id} does not exist`)
+  if (!role) throw new ExposedError(`Role ${id} does not exist`, 'ROLE_NOT_FOUND')
 
   // Ensure they exist in bm_web_users
   await state.dbPool('bm_web_users')

--- a/server/graphql/resolvers/mutations/create-appeal-comment.js
+++ b/server/graphql/resolvers/mutations/create-appeal-comment.js
@@ -8,21 +8,21 @@ module.exports = async function createAppealComment (obj, { id: appealId, input 
   const [appeal] = await state.dbPool('bm_web_appeals')
     .where({ id: appealId })
 
-  if (!appeal) throw new ExposedError(`Appeal ${appealId} does not exist`)
+  if (!appeal) throw new ExposedError(`Appeal ${appealId} does not exist`, 'APPEAL_NOT_FOUND')
 
   const hasPermission = state.acl.hasServerPermission(appeal.server_id, 'player.appeals', 'comment.any') ||
     (state.acl.hasServerPermission(appeal.server_id, 'player.appeals', 'comment.own') && state.acl.owns(appeal.actor_id)) ||
     (state.acl.hasServerPermission(appeal.server_id, 'player.appeals', 'comment.assigned') && state.acl.owns(appeal.assignee_id))
 
-  if (!hasPermission) throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
-  if (appeal.state_id > 2) throw new ExposedError('You cannot comment on a closed appeal')
+  if (!hasPermission) throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
+  if (appeal.state_id > 2) throw new ExposedError('You cannot comment on a closed appeal', 'INVALID_STATE')
 
   const hasDocuments = input.documents && input.documents.length > 0
 
   if (hasDocuments) {
     const hasAttachPermission = state.acl.hasServerPermission(appeal.server_id, 'player.appeals', 'attachment.create')
     if (!hasAttachPermission) {
-      throw new ExposedError('You do not have permission to attach files')
+      throw new ExposedError('You do not have permission to attach files', 'NO_PERMISSION')
     }
   }
 

--- a/server/graphql/resolvers/mutations/create-appeal.js
+++ b/server/graphql/resolvers/mutations/create-appeal.js
@@ -5,7 +5,7 @@ const { triggerWebhook } = require('../../../data/webhook')
 const { unparse } = require('uuid-parse')
 
 module.exports = async function createAppeal (obj, { input: { serverId, punishmentId, type, reason, documents } }, { log, state, session }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const exists = await state.dbPool('bm_web_appeals')
     .where({ server_id: serverId, punishment_id: punishmentId, punishment_type: type })
@@ -13,7 +13,7 @@ module.exports = async function createAppeal (obj, { input: { serverId, punishme
     .first()
 
   if (exists) {
-    throw new ExposedError('An appeal already exists for this punishment')
+    throw new ExposedError('An appeal already exists for this punishment', 'ALREADY_EXISTS')
   }
 
   const server = state.serversPool.get(serverId)
@@ -25,7 +25,7 @@ module.exports = async function createAppeal (obj, { input: { serverId, punishme
     case 'PlayerBan':
       if (!canAny && !state.acl.hasServerPermission(serverId, 'player.appeals', 'create.ban')) {
         throw new ExposedError(
-          'You do not have permission to perform this action, please contact your server administrator')
+          'You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
       }
 
       data = await server.pool(server.config.tables.playerBans).where({ id: punishmentId }).first()
@@ -34,7 +34,7 @@ module.exports = async function createAppeal (obj, { input: { serverId, punishme
     case 'PlayerKick':
       if (!canAny && !state.acl.hasServerPermission(serverId, 'player.appeals', 'create.kick')) {
         throw new ExposedError(
-          'You do not have permission to perform this action, please contact your server administrator')
+          'You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
       }
 
       data = await server.pool(server.config.tables.playerKicks).where({ id: punishmentId }).first()
@@ -43,7 +43,7 @@ module.exports = async function createAppeal (obj, { input: { serverId, punishme
     case 'PlayerMute':
       if (!canAny && !state.acl.hasServerPermission(serverId, 'player.appeals', 'create.mute')) {
         throw new ExposedError(
-          'You do not have permission to perform this action, please contact your server administrator')
+          'You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
       }
 
       data = await server.pool(server.config.tables.playerMutes).where({ id: punishmentId }).first()
@@ -52,19 +52,19 @@ module.exports = async function createAppeal (obj, { input: { serverId, punishme
     case 'PlayerWarning':
       if (!canAny && !state.acl.hasServerPermission(serverId, 'player.appeals', 'create.warning')) {
         throw new ExposedError(
-          'You do not have permission to perform this action, please contact your server administrator')
+          'You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
       }
 
       data = await server.pool(server.config.tables.playerWarnings).where({ id: punishmentId }).first()
 
       break
     default:
-      throw new ExposedError(`Invalid ${type} as punishment type`)
+      throw new ExposedError(`Invalid ${type} as punishment type`, 'INVALID_INPUT')
   }
 
-  if (!data) throw new ExposedError(`Could not find ${type} of id ${punishmentId}`)
+  if (!data) throw new ExposedError(`Could not find ${type} of id ${punishmentId}`, 'PUNISHMENT_NOT_FOUND')
 
-  if (!state.acl.owns(data.player_id)) throw new ExposedError('You cannot appeal a punishment you do not own')
+  if (!state.acl.owns(data.player_id)) throw new ExposedError('You cannot appeal a punishment you do not own', 'INVALID_TARGET')
 
   const appeal = {
     server_id: serverId,

--- a/server/graphql/resolvers/mutations/create-notification-rule.js
+++ b/server/graphql/resolvers/mutations/create-notification-rule.js
@@ -5,14 +5,14 @@ module.exports = async function createNotificationRule (obj, { input: { type, ro
   if (serverId) {
     const server = state.serversPool.get(serverId)
 
-    if (!server) throw new ExposedError(`Server ${serverId} does not exist`)
+    if (!server) throw new ExposedError(`Server ${serverId} does not exist`, 'SERVER_NOT_FOUND')
   }
 
   const roleIds = roles.map(role => role.id)
   const data = await state.dbPool('bm_web_roles').select('role_id').whereIn('role_id', roleIds)
 
   if (data.length !== roleIds.length) {
-    throw new ExposedError('Invalid role')
+    throw new ExposedError('Invalid role', 'INVALID_INPUT')
   }
 
   let id

--- a/server/graphql/resolvers/mutations/create-player-ban.js
+++ b/server/graphql/resolvers/mutations/create-player-ban.js
@@ -21,7 +21,7 @@ module.exports = async function createPlayerBan (obj, { input }, { session, stat
     id = insertId
   } catch (e) {
     if (e.code === 'ER_DUP_ENTRY') {
-      throw new ExposedError('Player already banned on selected server, please unban first')
+      throw new ExposedError('Player already banned on selected server, please unban first', 'ALREADY_EXISTS')
     }
 
     throw e

--- a/server/graphql/resolvers/mutations/create-player-mute.js
+++ b/server/graphql/resolvers/mutations/create-player-mute.js
@@ -23,7 +23,7 @@ module.exports = async function createPlayerMute (obj, { input }, { session, sta
     id = insertId
   } catch (e) {
     if (e.code === 'ER_DUP_ENTRY') {
-      throw new ExposedError('Player already muted on selected server, please unmute first')
+      throw new ExposedError('Player already muted on selected server, please unmute first', 'ALREADY_EXISTS')
     }
 
     throw e

--- a/server/graphql/resolvers/mutations/create-report-comment.js
+++ b/server/graphql/resolvers/mutations/create-report-comment.js
@@ -6,27 +6,27 @@ const reportComment = require('../queries/report-comment')
 module.exports = async function createReportComment (obj, { report: reportId, serverId, input }, { session, state }, info) {
   const server = state.serversPool.get(serverId)
 
-  if (!server) throw new ExposedError(`Server ${serverId} does not exist`)
+  if (!server) throw new ExposedError(`Server ${serverId} does not exist`, 'SERVER_NOT_FOUND')
 
   const [data] = await server.pool(server.config.tables.playerReports)
     .where({ id: reportId })
 
-  if (!data) throw new ExposedError(`Report ${reportId} does not exist`)
+  if (!data) throw new ExposedError(`Report ${reportId} does not exist`, 'REPORT_NOT_FOUND')
 
   const hasPermission = state.acl.hasServerPermission(serverId, 'player.reports', 'comment.any') ||
     (state.acl.hasServerPermission(serverId, 'player.reports', 'comment.own') && state.acl.owns(data.actor_id)) ||
     (state.acl.hasServerPermission(serverId, 'player.reports', 'comment.assigned') && state.acl.owns(data.assignee_id)) ||
     (state.acl.hasServerPermission(serverId, 'player.reports', 'comment.reported') && state.acl.owns(data.player_id))
 
-  if (!hasPermission) throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
-  if (data.state_id > 2) throw new ExposedError('You cannot comment on a closed report')
+  if (!hasPermission) throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
+  if (data.state_id > 2) throw new ExposedError('You cannot comment on a closed report', 'INVALID_STATE')
 
   const hasDocuments = input.documents && input.documents.length > 0
 
   if (hasDocuments) {
     const hasAttachPermission = state.acl.hasServerPermission(serverId, 'player.reports', 'attachment.create')
     if (!hasAttachPermission) {
-      throw new ExposedError('You do not have permission to attach files')
+      throw new ExposedError('You do not have permission to attach files', 'NO_PERMISSION')
     }
   }
 

--- a/server/graphql/resolvers/mutations/create-role.js
+++ b/server/graphql/resolvers/mutations/create-role.js
@@ -3,7 +3,7 @@ const ExposedError = require('../../../data/exposed-error')
 const role = require('../queries/role')
 
 module.exports = async function createRole (obj, { input: { name, parent, resources } }, { state }, info) {
-  if (parent < 1 || parent > 3) throw new ExposedError('Invalid parent')
+  if (parent < 1 || parent > 3) throw new ExposedError('Invalid parent', 'INVALID_INPUT')
 
   let id
 

--- a/server/graphql/resolvers/mutations/create-server.js
+++ b/server/graphql/resolvers/mutations/create-server.js
@@ -13,7 +13,7 @@ module.exports = async function createServer (obj, { input }, { log, state }) {
     .first()
 
   if (serverExists) {
-    throw new ExposedError('A server with this name already exists')
+    throw new ExposedError('A server with this name already exists', 'ALREADY_EXISTS')
   }
 
   const id = await generateServerId()
@@ -42,7 +42,7 @@ module.exports = async function createServer (obj, { input }, { log, state }) {
 
   if (tablesMissing.length) {
     await conn.end()
-    throw new ExposedError(`Tables do not exist in the database: ${tablesMissing.join(', ')}`)
+    throw new ExposedError(`Tables do not exist in the database: ${tablesMissing.join(', ')}`, 'MISSING_DATABASE_TABLES')
   }
 
   const [[exists]] = await conn.query(
@@ -52,7 +52,7 @@ module.exports = async function createServer (obj, { input }, { log, state }) {
   await conn.end()
 
   if (!exists) {
-    throw new ExposedError(`Console UUID not found in ${input.tables.players} table`)
+    throw new ExposedError(`Console UUID not found in ${input.tables.players} table`, 'CONSOLE_UUID_NOT_FOUND')
   }
 
   const password = input.password

--- a/server/graphql/resolvers/mutations/create-webhook.js
+++ b/server/graphql/resolvers/mutations/create-webhook.js
@@ -5,7 +5,7 @@ module.exports = async function createWebhook (obj, { input }, { state }, info) 
   if (input.serverId) {
     const server = state.serversPool.get(input.serverId)
 
-    if (!server) throw new ExposedError(`Server ${input.serverId} does not exist`)
+    if (!server) throw new ExposedError(`Server ${input.serverId} does not exist`, 'SERVER_NOT_FOUND')
   }
 
   const [id] = await state.dbPool('bm_web_webhooks').insert({

--- a/server/graphql/resolvers/mutations/delete-appeal-comment.js
+++ b/server/graphql/resolvers/mutations/delete-appeal-comment.js
@@ -5,7 +5,7 @@ const appealComment = require('../queries/appeal-comment')
 module.exports = async function deleteAppealComment (obj, { id }, { state }, info) {
   const comment = await appealComment(obj, { id }, { state }, info)
 
-  if (!comment.acl || !comment.acl.delete || !comment.content) throw new ExposedError('You do not have permission to perform this action')
+  if (!comment.acl || !comment.acl.delete || !comment.content) throw new ExposedError('You do not have permission to perform this action', 'NO_PERMISSION')
 
   await state.dbPool.transaction(async trx => {
     await trx('bm_web_appeal_comments')

--- a/server/graphql/resolvers/mutations/delete-document.js
+++ b/server/graphql/resolvers/mutations/delete-document.js
@@ -16,7 +16,7 @@ async function getDocumentContext (dbPool, documentId) {
       .where({ id: appealDoc.appeal_id })
       .select('server_id')
 
-    if (!appeal) throw new ExposedError('Parent appeal not found')
+    if (!appeal) throw new ExposedError('Parent appeal not found', 'APPEAL_NOT_FOUND')
     return { serverId: appeal.server_id, resource: 'player.appeals' }
   }
 
@@ -51,7 +51,7 @@ module.exports = async function deleteDocument (obj, { id }, { log, session, sta
     )
 
   if (!document) {
-    throw new ExposedError(`Document ${id} does not exist`)
+    throw new ExposedError(`Document ${id} does not exist`, 'DOCUMENT_NOT_FOUND')
   }
 
   const playerId = unparse(document.player_id)
@@ -64,12 +64,12 @@ module.exports = async function deleteDocument (obj, { id }, { log, session, sta
     const canDeleteOwn = state.acl.hasServerPermission(serverId, resource, 'attachment.delete.own') && isOwner
 
     if (!canDeleteAny && !canDeleteOwn) {
-      throw new ExposedError('You do not have permission to delete this document')
+      throw new ExposedError('You do not have permission to delete this document', 'NO_PERMISSION')
     }
   } else {
     // Unlinked document - only admins can delete
     if (!state.acl.hasPermission('servers', 'manage')) {
-      throw new ExposedError('You do not have permission to delete this document')
+      throw new ExposedError('You do not have permission to delete this document', 'NO_PERMISSION')
     }
   }
 

--- a/server/graphql/resolvers/mutations/delete-notification-rule.js
+++ b/server/graphql/resolvers/mutations/delete-notification-rule.js
@@ -4,7 +4,7 @@ const notificationRule = require('../queries/notification-rule')
 module.exports = async function deleteNotificationRule (obj, { id }, { state }, info) {
   const data = await notificationRule(obj, { id }, { state }, info)
 
-  if (!data) throw new ExposedError(`Notification rule ${id} does not exist`)
+  if (!data) throw new ExposedError(`Notification rule ${id} does not exist`, 'NOTIFICATION_NOT_FOUND')
 
   await state.dbPool('bm_web_notification_rules').where('id', id).del()
 

--- a/server/graphql/resolvers/mutations/delete-player-ban-record.js
+++ b/server/graphql/resolvers/mutations/delete-player-ban-record.js
@@ -3,7 +3,7 @@ const { parseResolveInfo } = require('graphql-parse-resolve-info')
 const { getSql } = require('../../utils')
 
 module.exports = async function deletePlayerBanRecord (obj, { id, serverId }, { state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const tables = server.config.tables
@@ -12,13 +12,13 @@ module.exports = async function deletePlayerBanRecord (obj, { id, serverId }, { 
     .select('pastActor_id')
     .where({ id })
 
-  if (!result) throw new ExposedError('Ban record not found')
+  if (!result) throw new ExposedError('Ban record not found', 'BAN_RECORD_NOT_FOUND')
 
   const canDelete = state.acl.hasServerPermission(serverId, 'player.bans', 'delete.any') ||
     (state.acl.hasServerPermission(serverId, 'player.bans', 'delete.own') && state.acl.owns(result.pastActor_id))
 
   if (!canDelete) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   const fields = parseResolveInfo(info)

--- a/server/graphql/resolvers/mutations/delete-player-ban.js
+++ b/server/graphql/resolvers/mutations/delete-player-ban.js
@@ -3,7 +3,7 @@ const ExposedError = require('../../../data/exposed-error')
 const playerBan = require('../queries/player-ban')
 
 module.exports = async function deletePlayerBan (obj, { id, serverId }, { session, state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const tables = server.config.tables
@@ -12,13 +12,13 @@ module.exports = async function deletePlayerBan (obj, { id, serverId }, { sessio
     .select('actor_id')
     .where({ id })
 
-  if (!result) throw new ExposedError('Ban not found')
+  if (!result) throw new ExposedError('Ban not found', 'BAN_NOT_FOUND')
 
   const canDelete = state.acl.hasServerPermission(serverId, 'player.bans', 'delete.any') ||
     (state.acl.hasServerPermission(serverId, 'player.bans', 'delete.own') && state.acl.owns(result.actor_id))
 
   if (!canDelete) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   const data = await playerBan(obj, { id, serverId }, { state }, info)

--- a/server/graphql/resolvers/mutations/delete-player-kick.js
+++ b/server/graphql/resolvers/mutations/delete-player-kick.js
@@ -2,7 +2,7 @@ const ExposedError = require('../../../data/exposed-error')
 const playerKick = require('../queries/player-kick')
 
 module.exports = async function deletePlayerKick (obj, { id, serverId }, { session, state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const tables = server.config.tables
@@ -11,13 +11,13 @@ module.exports = async function deletePlayerKick (obj, { id, serverId }, { sessi
     .select('actor_id')
     .where({ id })
 
-  if (!result) throw new ExposedError('Kick not found')
+  if (!result) throw new ExposedError('Kick not found', 'KICK_NOT_FOUND')
 
   const canDelete = state.acl.hasServerPermission(serverId, 'player.kicks', 'delete.any') ||
     (state.acl.hasServerPermission(serverId, 'player.kicks', 'delete.own') && state.acl.owns(result.actor_id))
 
   if (!canDelete) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   const data = await playerKick(obj, { id, serverId }, { state }, info)

--- a/server/graphql/resolvers/mutations/delete-player-mute-record.js
+++ b/server/graphql/resolvers/mutations/delete-player-mute-record.js
@@ -3,7 +3,7 @@ const { parseResolveInfo } = require('graphql-parse-resolve-info')
 const { getSql } = require('../../utils')
 
 module.exports = async function deletePlayerMuteRecord (obj, { id, serverId }, { state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const tables = server.config.tables
@@ -12,13 +12,13 @@ module.exports = async function deletePlayerMuteRecord (obj, { id, serverId }, {
     .select('pastActor_id')
     .where({ id })
 
-  if (!result) throw new ExposedError('Mute record not found')
+  if (!result) throw new ExposedError('Mute record not found', 'MUTE_RECORD_NOT_FOUND')
 
   const canDelete = state.acl.hasServerPermission(serverId, 'player.mutes', 'delete.any') ||
     (state.acl.hasServerPermission(serverId, 'player.mutes', 'delete.own') && state.acl.owns(result.pastActor_id))
 
   if (!canDelete) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   const fields = parseResolveInfo(info)

--- a/server/graphql/resolvers/mutations/delete-player-mute.js
+++ b/server/graphql/resolvers/mutations/delete-player-mute.js
@@ -3,7 +3,7 @@ const ExposedError = require('../../../data/exposed-error')
 const playerMute = require('../queries/player-mute')
 
 module.exports = async function deletePlayerMute (obj, { id, serverId }, { session, state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const tables = server.config.tables
@@ -12,13 +12,13 @@ module.exports = async function deletePlayerMute (obj, { id, serverId }, { sessi
     .select('actor_id')
     .where({ id })
 
-  if (!result) throw new ExposedError('Mute not found')
+  if (!result) throw new ExposedError('Mute not found', 'MUTE_NOT_FOUND')
 
   const canDelete = state.acl.hasServerPermission(serverId, 'player.mutes', 'delete.any') ||
     (state.acl.hasServerPermission(serverId, 'player.mutes', 'delete.own') && state.acl.owns(result.actor_id))
 
   if (!canDelete) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   const data = await playerMute(obj, { id, serverId }, { state }, info)

--- a/server/graphql/resolvers/mutations/delete-player-note.js
+++ b/server/graphql/resolvers/mutations/delete-player-note.js
@@ -2,7 +2,7 @@ const ExposedError = require('../../../data/exposed-error')
 const playerNote = require('../queries/player-note')
 
 module.exports = async function deletePlayerNote (obj, { id, serverId }, { session, state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const tables = server.config.tables
@@ -11,13 +11,13 @@ module.exports = async function deletePlayerNote (obj, { id, serverId }, { sessi
     .select('actor_id')
     .where({ id })
 
-  if (!result) throw new ExposedError('Note not found')
+  if (!result) throw new ExposedError('Note not found', 'NOTE_NOT_FOUND')
 
   const canDelete = state.acl.hasServerPermission(serverId, 'player.notes', 'delete.any') ||
     (state.acl.hasServerPermission(serverId, 'player.notes', 'delete.own') && state.acl.owns(result.actor_id))
 
   if (!canDelete) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   const data = await playerNote(obj, { id, serverId }, { state }, info)

--- a/server/graphql/resolvers/mutations/delete-player-warning.js
+++ b/server/graphql/resolvers/mutations/delete-player-warning.js
@@ -2,7 +2,7 @@ const ExposedError = require('../../../data/exposed-error')
 const playerWarning = require('../queries/player-warning')
 
 module.exports = async function deletePlayerWarning (obj, { id, serverId }, { session, state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const tables = server.config.tables
@@ -11,13 +11,13 @@ module.exports = async function deletePlayerWarning (obj, { id, serverId }, { se
     .select('actor_id')
     .where({ id })
 
-  if (!result) throw new ExposedError('Warning not found')
+  if (!result) throw new ExposedError('Warning not found', 'WARNING_NOT_FOUND')
 
   const canDelete = state.acl.hasServerPermission(serverId, 'player.warnings', 'delete.any') ||
     (state.acl.hasServerPermission(serverId, 'player.warnings', 'delete.own') && state.acl.owns(result.actor_id))
 
   if (!canDelete) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   const data = await playerWarning(obj, { id, serverId }, { state }, info)

--- a/server/graphql/resolvers/mutations/delete-report-comment.js
+++ b/server/graphql/resolvers/mutations/delete-report-comment.js
@@ -3,12 +3,12 @@ const { getNotificationType } = require('../../../data/notification')
 const reportComment = require('../queries/report-comment')
 
 module.exports = async function deleteReportComment (obj, { id, serverId }, { state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const comment = await reportComment(obj, { id, serverId }, { state }, info)
 
-  if (!comment.acl || !comment.acl.delete) throw new ExposedError('You do not have permission to perform this action')
+  if (!comment.acl || !comment.acl.delete) throw new ExposedError('You do not have permission to perform this action', 'NO_PERMISSION')
 
   await server.pool(server.config.tables.playerReportComments)
     .where({ id })

--- a/server/graphql/resolvers/mutations/delete-role.js
+++ b/server/graphql/resolvers/mutations/delete-role.js
@@ -2,11 +2,11 @@ const role = require('../queries/role')
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function deleteRole (obj, { id }, { state }, info) {
-  if (id < 4) throw new ExposedError('You may not delete default roles')
+  if (id < 4) throw new ExposedError('You may not delete default roles', 'DEFAULT_ROLE_PROTECTED')
 
   const data = await role(obj, { id }, { state }, info)
 
-  if (!data) throw new ExposedError(`Role ${id} does not exist`)
+  if (!data) throw new ExposedError(`Role ${id} does not exist`, 'ROLE_NOT_FOUND')
 
   await state.dbPool('bm_web_roles').where('role_id', id).del()
 

--- a/server/graphql/resolvers/mutations/delete-server.js
+++ b/server/graphql/resolvers/mutations/delete-server.js
@@ -1,8 +1,8 @@
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function deleteServer (obj, { id }, { state }) {
-  if (!state.serversPool.has(id)) throw new ExposedError('Server does not exist')
-  if (state.serversPool.size === 1) throw new ExposedError('Cannot delete only server, please add a new server and then delete the old one')
+  if (!state.serversPool.has(id)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
+  if (state.serversPool.size === 1) throw new ExposedError('Cannot delete only server, please add a new server and then delete the old one', 'CANNOT_DELETE_LAST_SERVER')
 
   await state.dbPool('bm_web_servers').where('id', id).del()
 

--- a/server/graphql/resolvers/mutations/delete-webhook.js
+++ b/server/graphql/resolvers/mutations/delete-webhook.js
@@ -4,7 +4,7 @@ const webhook = require('../queries/webhook')
 module.exports = async function deleteWebhook (obj, { id }, { state }, info) {
   const data = await webhook(obj, { id }, { state }, info)
 
-  if (!data) throw new ExposedError(`Webhook ${id} does not exist`)
+  if (!data) throw new ExposedError(`Webhook ${id} does not exist`, 'WEBHOOK_NOT_FOUND')
 
   await state.dbPool('bm_web_webhooks')
     .where({ id })

--- a/server/graphql/resolvers/mutations/report-state.js
+++ b/server/graphql/resolvers/mutations/report-state.js
@@ -6,12 +6,12 @@ const { subscribeReport, notifyReport } = require('../../../data/notification/re
 module.exports = async function reportState (obj, { serverId, state: stateId, report: id }, { session, state }, info) {
   const server = state.serversPool.get(serverId)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const table = server.config.tables.playerReports
   const [data] = await server.pool(table).where({ id })
 
-  if (!data) throw new ExposedError(`Report ${id} does not exist`)
+  if (!data) throw new ExposedError(`Report ${id} does not exist`, 'REPORT_NOT_FOUND')
 
   const canUpdate = state.acl.hasServerPermission(serverId, 'player.reports', 'update.state.any') ||
     (state.acl.hasServerPermission(serverId, 'player.reports', 'update.state.own') && state.acl.owns(data.actor_id)) ||
@@ -19,12 +19,12 @@ module.exports = async function reportState (obj, { serverId, state: stateId, re
     (state.acl.hasServerPermission(serverId, 'player.reports', 'update.state.reported') && state.acl.owns(data.player_id))
 
   if (!canUpdate) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   const row = await server.pool(server.config.tables.playerReportStates).where('id', stateId).first()
 
-  if (!row) throw new ExposedError(`Report State ${stateId} does not exist`)
+  if (!row) throw new ExposedError(`Report State ${stateId} does not exist`, 'REPORT_STATE_NOT_FOUND')
 
   await server.pool(table).update({ updated: server.pool.raw('UNIX_TIMESTAMP()'), state_id: stateId }).where({ id })
 

--- a/server/graphql/resolvers/mutations/report-subscription-state.js
+++ b/server/graphql/resolvers/mutations/report-subscription-state.js
@@ -4,20 +4,20 @@ const { subscribeReport, unsubscribeReport, getReportSubscription } = require('.
 module.exports = async function reportSubscriptionState (obj, { serverId, report: id, subscriptionState }, { session, state }, info) {
   const server = state.serversPool.get(serverId)
 
-  if (!server) throw new ExposedError(`Server ${serverId} does not exist`)
+  if (!server) throw new ExposedError(`Server ${serverId} does not exist`, 'SERVER_NOT_FOUND')
 
   const data = await server.pool(server.config.tables.playerReports)
     .where({ id })
     .first()
 
-  if (!data) throw new ExposedError(`Report ${id} does not exist`)
+  if (!data) throw new ExposedError(`Report ${id} does not exist`, 'REPORT_NOT_FOUND')
 
   const canView = state.acl.hasServerPermission(serverId, 'player.reports', 'view.any') ||
     (state.acl.hasServerPermission(serverId, 'player.reports', 'view.own') && state.acl.owns(data.actor_id)) ||
     (state.acl.hasServerPermission(serverId, 'player.reports', 'view.assigned') && state.acl.owns(data.assignee_id)) ||
     (state.acl.hasServerPermission(serverId, 'player.reports', 'view.reported') && state.acl.owns(data.player_id))
 
-  if (!canView) throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+  if (!canView) throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
 
   if (subscriptionState === 'SUBSCRIBED') {
     await subscribeReport(state.dbPool, id, serverId, session.playerId)

--- a/server/graphql/resolvers/mutations/resolve-appeal-delete-ban.js
+++ b/server/graphql/resolvers/mutations/resolve-appeal-delete-ban.js
@@ -9,17 +9,17 @@ module.exports = async function resolveAppealDeleteBan (obj, { id }, { session, 
     .where({ id })
     .first()
 
-  if (!data) throw new ExposedError(`Appeal ${id} does not exist`)
+  if (!data) throw new ExposedError(`Appeal ${id} does not exist`, 'APPEAL_NOT_FOUND')
 
   const server = state.serversPool.get(data.server_id)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const punishment = await server.pool(server.config.tables.playerBans)
     .where({ id: data.punishment_id })
     .first()
 
-  if (!punishment) throw new ExposedError('Punishment associated with this appeal no longer exists')
+  if (!punishment) throw new ExposedError('Punishment associated with this appeal no longer exists', 'PUNISHMENT_NOT_FOUND')
 
   const canUpdate = state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.any') ||
     (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.own') && state.acl.owns(data.actor_id)) ||
@@ -28,7 +28,7 @@ module.exports = async function resolveAppealDeleteBan (obj, { id }, { session, 
     (state.acl.hasServerPermission(data.server_id, 'player.bans', 'delete.own') && state.acl.owns(punishment.actor_id))
 
   if (!canUpdate || !canDelete) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   let commentId

--- a/server/graphql/resolvers/mutations/resolve-appeal-delete-mute.js
+++ b/server/graphql/resolvers/mutations/resolve-appeal-delete-mute.js
@@ -9,17 +9,17 @@ module.exports = async function resolveAppealDeleteMute (obj, { id }, { session,
     .where({ id })
     .first()
 
-  if (!data) throw new ExposedError(`Appeal ${id} does not exist`)
+  if (!data) throw new ExposedError(`Appeal ${id} does not exist`, 'APPEAL_NOT_FOUND')
 
   const server = state.serversPool.get(data.server_id)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const punishment = await server.pool(server.config.tables.playerMutes)
     .where({ id: data.punishment_id })
     .first()
 
-  if (!punishment) throw new ExposedError('Punishment associated with this appeal no longer exists')
+  if (!punishment) throw new ExposedError('Punishment associated with this appeal no longer exists', 'PUNISHMENT_NOT_FOUND')
 
   const canUpdate = state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.any') ||
     (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.own') && state.acl.owns(data.actor_id)) ||
@@ -28,7 +28,7 @@ module.exports = async function resolveAppealDeleteMute (obj, { id }, { session,
     (state.acl.hasServerPermission(data.server_id, 'player.mutes', 'delete.own') && state.acl.owns(punishment.actor_id))
 
   if (!canUpdate || !canDelete) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   let commentId

--- a/server/graphql/resolvers/mutations/resolve-appeal-delete-warning.js
+++ b/server/graphql/resolvers/mutations/resolve-appeal-delete-warning.js
@@ -8,17 +8,17 @@ module.exports = async function resolveAppealDeleteWarning (obj, { id }, { sessi
     .where({ id })
     .first()
 
-  if (!data) throw new ExposedError(`Appeal ${id} does not exist`)
+  if (!data) throw new ExposedError(`Appeal ${id} does not exist`, 'APPEAL_NOT_FOUND')
 
   const server = state.serversPool.get(data.server_id)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const punishment = await server.pool(server.config.tables.playerWarnings)
     .where({ id: data.punishment_id })
     .first()
 
-  if (!punishment) throw new ExposedError('Punishment associated with this appeal no longer exists')
+  if (!punishment) throw new ExposedError('Punishment associated with this appeal no longer exists', 'PUNISHMENT_NOT_FOUND')
 
   const canUpdate = state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.any') ||
     (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.own') && state.acl.owns(data.actor_id)) ||
@@ -27,7 +27,7 @@ module.exports = async function resolveAppealDeleteWarning (obj, { id }, { sessi
     (state.acl.hasServerPermission(data.server_id, 'player.warnings', 'delete.own') && state.acl.owns(punishment.actor_id))
 
   if (!canUpdate || !canDelete) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   let commentId

--- a/server/graphql/resolvers/mutations/resolve-appeal-update-ban.js
+++ b/server/graphql/resolvers/mutations/resolve-appeal-update-ban.js
@@ -8,17 +8,17 @@ module.exports = async function resolveAppealUpdateBan (obj, { id, input }, { se
     .where({ id })
     .first()
 
-  if (!data) throw new ExposedError(`Appeal ${id} does not exist`)
+  if (!data) throw new ExposedError(`Appeal ${id} does not exist`, 'APPEAL_NOT_FOUND')
 
   const server = state.serversPool.get(data.server_id)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const punishment = await server.pool(server.config.tables.playerBans)
     .where({ id: data.punishment_id })
     .first()
 
-  if (!punishment) throw new ExposedError('Punishment associated with this appeal no longer exists')
+  if (!punishment) throw new ExposedError('Punishment associated with this appeal no longer exists', 'PUNISHMENT_NOT_FOUND')
 
   const canUpdate = state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.any') ||
     (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.own') && state.acl.owns(data.actor_id)) ||
@@ -27,7 +27,7 @@ module.exports = async function resolveAppealUpdateBan (obj, { id, input }, { se
     (state.acl.hasServerPermission(data.server_id, 'player.bans', 'update.own') && state.acl.owns(punishment.actor_id))
 
   if (!canUpdate || !canUpdatePunishment) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   let commentId

--- a/server/graphql/resolvers/mutations/resolve-appeal-update-mute.js
+++ b/server/graphql/resolvers/mutations/resolve-appeal-update-mute.js
@@ -8,17 +8,17 @@ module.exports = async function resolveAppealUpdateMute (obj, { id, input }, { s
     .where({ id })
     .first()
 
-  if (!data) throw new ExposedError(`Appeal ${id} does not exist`)
+  if (!data) throw new ExposedError(`Appeal ${id} does not exist`, 'APPEAL_NOT_FOUND')
 
   const server = state.serversPool.get(data.server_id)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const punishment = await server.pool(server.config.tables.playerMutes)
     .where({ id: data.punishment_id })
     .first()
 
-  if (!punishment) throw new ExposedError('Punishment associated with this appeal no longer exists')
+  if (!punishment) throw new ExposedError('Punishment associated with this appeal no longer exists', 'PUNISHMENT_NOT_FOUND')
 
   const canUpdate = state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.any') ||
     (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.own') && state.acl.owns(data.actor_id)) ||
@@ -27,7 +27,7 @@ module.exports = async function resolveAppealUpdateMute (obj, { id, input }, { s
     (state.acl.hasServerPermission(data.server_id, 'player.mutes', 'update.own') && state.acl.owns(punishment.actor_id))
 
   if (!canUpdate || !canUpdatePunishment) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   let commentId

--- a/server/graphql/resolvers/mutations/resolve-appeal-update-warning.js
+++ b/server/graphql/resolvers/mutations/resolve-appeal-update-warning.js
@@ -8,17 +8,17 @@ module.exports = async function resolveAppealUpdateWarning (obj, { id, input }, 
     .where({ id })
     .first()
 
-  if (!data) throw new ExposedError(`Appeal ${id} does not exist`)
+  if (!data) throw new ExposedError(`Appeal ${id} does not exist`, 'APPEAL_NOT_FOUND')
 
   const server = state.serversPool.get(data.server_id)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const punishment = await server.pool(server.config.tables.playerWarnings)
     .where({ id: data.punishment_id })
     .first()
 
-  if (!punishment) throw new ExposedError('Punishment associated with this appeal no longer exists')
+  if (!punishment) throw new ExposedError('Punishment associated with this appeal no longer exists', 'PUNISHMENT_NOT_FOUND')
 
   const canUpdate = state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.any') ||
     (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'update.state.own') && state.acl.owns(data.actor_id)) ||
@@ -27,7 +27,7 @@ module.exports = async function resolveAppealUpdateWarning (obj, { id, input }, 
     (state.acl.hasServerPermission(data.server_id, 'player.warnings', 'update.own') && state.acl.owns(punishment.actor_id))
 
   if (!canUpdate || !canUpdatePunishment) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   let commentId

--- a/server/graphql/resolvers/mutations/resolve-report-ban.js
+++ b/server/graphql/resolvers/mutations/resolve-report-ban.js
@@ -8,7 +8,7 @@ const { subscribeReport, notifyReport } = require('../../../data/notification/re
 module.exports = async function resolveReportBan (obj, { report: reportId, serverId, input }, { session, state }, info) {
   const server = state.serversPool.get(serverId)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const table = server.config.tables.playerReports
   const player = input.player
@@ -16,7 +16,7 @@ module.exports = async function resolveReportBan (obj, { report: reportId, serve
 
   const [data] = await server.pool(table).where({ id: reportId })
 
-  if (!data) throw new ExposedError(`Report ${reportId} does not exist`)
+  if (!data) throw new ExposedError(`Report ${reportId} does not exist`, 'REPORT_NOT_FOUND')
 
   const canUpdate = state.acl.hasServerPermission(serverId, 'player.reports', 'update.state.any') ||
     (state.acl.hasServerPermission(serverId, 'player.reports', 'update.state.own') && state.acl.owns(data.actor_id)) ||
@@ -24,7 +24,7 @@ module.exports = async function resolveReportBan (obj, { report: reportId, serve
     (state.acl.hasServerPermission(serverId, 'player.reports', 'update.state.reported') && state.acl.owns(data.player_id))
 
   if (!canUpdate) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   const { name } = await server.pool(server.config.tables.players).select('name').where({ id: player }).first()
@@ -42,7 +42,7 @@ module.exports = async function resolveReportBan (obj, { report: reportId, serve
       })
     } catch (e) {
       if (e.code === 'ER_DUP_ENTRY') {
-        throw new ExposedError('Player already banned on selected server, please unban first')
+        throw new ExposedError('Player already banned on selected server, please unban first', 'ALREADY_EXISTS')
       }
 
       throw e

--- a/server/graphql/resolvers/mutations/resolve-report-mute.js
+++ b/server/graphql/resolvers/mutations/resolve-report-mute.js
@@ -8,7 +8,7 @@ const { subscribeReport, notifyReport } = require('../../../data/notification/re
 module.exports = async function resolveReportMute (obj, { report: reportId, serverId, input }, { session, state }, info) {
   const server = state.serversPool.get(serverId)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const table = server.config.tables.playerReports
   const player = input.player
@@ -16,7 +16,7 @@ module.exports = async function resolveReportMute (obj, { report: reportId, serv
 
   const [data] = await server.pool(table).where({ id: reportId })
 
-  if (!data) throw new ExposedError(`Report ${reportId} does not exist`)
+  if (!data) throw new ExposedError(`Report ${reportId} does not exist`, 'REPORT_NOT_FOUND')
 
   const canUpdate = state.acl.hasServerPermission(serverId, 'player.reports', 'update.state.any') ||
     (state.acl.hasServerPermission(serverId, 'player.reports', 'update.state.own') && state.acl.owns(data.actor_id)) ||
@@ -24,7 +24,7 @@ module.exports = async function resolveReportMute (obj, { report: reportId, serv
     (state.acl.hasServerPermission(serverId, 'player.reports', 'update.state.reported') && state.acl.owns(data.player_id))
 
   if (!canUpdate) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   const { name } = await server.pool(server.config.tables.players).select('name').where({ id: player }).first()
@@ -43,7 +43,7 @@ module.exports = async function resolveReportMute (obj, { report: reportId, serv
       })
     } catch (e) {
       if (e.code === 'ER_DUP_ENTRY') {
-        throw new ExposedError('Player already muted on selected server, please unmute first')
+        throw new ExposedError('Player already muted on selected server, please unmute first', 'ALREADY_EXISTS')
       }
 
       throw e

--- a/server/graphql/resolvers/mutations/resolve-report-warning.js
+++ b/server/graphql/resolvers/mutations/resolve-report-warning.js
@@ -8,7 +8,7 @@ const { subscribeReport, notifyReport } = require('../../../data/notification/re
 module.exports = async function resolveReportWarning (obj, { report: reportId, serverId, input }, { session, state }, info) {
   const server = state.serversPool.get(serverId)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const table = server.config.tables.playerReports
   const player = input.player
@@ -16,7 +16,7 @@ module.exports = async function resolveReportWarning (obj, { report: reportId, s
 
   const [data] = await server.pool(table).where({ id: reportId })
 
-  if (!data) throw new ExposedError(`Report ${reportId} does not exist`)
+  if (!data) throw new ExposedError(`Report ${reportId} does not exist`, 'REPORT_NOT_FOUND')
 
   const canUpdate = state.acl.hasServerPermission(serverId, 'player.reports', 'update.state.any') ||
     (state.acl.hasServerPermission(serverId, 'player.reports', 'update.state.own') && state.acl.owns(data.actor_id)) ||
@@ -24,7 +24,7 @@ module.exports = async function resolveReportWarning (obj, { report: reportId, s
     (state.acl.hasServerPermission(serverId, 'player.reports', 'update.state.reported') && state.acl.owns(data.player_id))
 
   if (!canUpdate) {
-    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator')
+    throw new ExposedError('You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
   }
 
   const { name } = await server.pool(server.config.tables.players).select('name').where({ id: player }).first()

--- a/server/graphql/resolvers/mutations/set-email.js
+++ b/server/graphql/resolvers/mutations/set-email.js
@@ -5,26 +5,26 @@ const Me = require('../queries/me')
 
 module.exports = async function setEmail (obj, { currentPassword, email }, { session, state }) {
   if (!isLength(currentPassword, { min: 6, max: 255 })) {
-    throw new ExposedError('Invalid password, minimum length 6 characters')
+    throw new ExposedError('Invalid password, minimum length 6 characters', 'INVALID_PASSWORD')
   }
 
-  if (!isEmail(email)) throw new ExposedError('Invalid email address')
+  if (!isEmail(email)) throw new ExposedError('Invalid email address', 'INVALID_EMAIL')
 
   const [checkResult] = await state.dbPool('bm_web_users')
     .select('player_id', 'password')
     .where('player_id', session.playerId)
 
-  if (!checkResult) throw new ExposedError('You do not have an account, please register')
+  if (!checkResult) throw new ExposedError('You do not have an account, please register', 'NO_ACCOUNT')
 
   const match = await verify(checkResult.password, currentPassword)
 
-  if (!match) throw new ExposedError('Incorrect login details')
+  if (!match) throw new ExposedError('Incorrect login details', 'INCORRECT_LOGIN')
 
   const [emailResult] = await state.dbPool('bm_web_users')
     .select('email')
     .where('email', email)
 
-  if (emailResult) throw new ExposedError('You already have an account')
+  if (emailResult) throw new ExposedError('You already have an account', 'EMAIL_IN_USE')
 
   await state.dbPool('bm_web_users')
     .update('email', email)

--- a/server/graphql/resolvers/mutations/set-email.js
+++ b/server/graphql/resolvers/mutations/set-email.js
@@ -5,7 +5,7 @@ const Me = require('../queries/me')
 
 module.exports = async function setEmail (obj, { currentPassword, email }, { session, state }) {
   if (!isLength(currentPassword, { min: 6, max: 255 })) {
-    throw new ExposedError('Invalid password, minimum length 6 characters', 'INVALID_PASSWORD')
+    throw new ExposedError('Invalid password, minimum length 6 characters', 'INVALID_PASSWORD_LENGTH', { minLength: 6 })
   }
 
   if (!isEmail(email)) throw new ExposedError('Invalid email address', 'INVALID_EMAIL')

--- a/server/graphql/resolvers/mutations/set-locale.js
+++ b/server/graphql/resolvers/mutations/set-locale.js
@@ -1,0 +1,15 @@
+const ExposedError = require('../../../data/exposed-error')
+const { isSupportedLocale } = require('../../../data/locales')
+const Me = require('../queries/me')
+
+module.exports = async function setLocale (obj, { locale }, { session, state, log }) {
+  if (!isSupportedLocale(locale)) {
+    throw new ExposedError('Locale is not supported', 'INVALID_LOCALE')
+  }
+
+  await state.dbPool('bm_web_users')
+    .update('locale', locale)
+    .where('player_id', session.playerId)
+
+  return Me(obj, {}, { session, state, log })
+}

--- a/server/graphql/resolvers/mutations/set-password.js
+++ b/server/graphql/resolvers/mutations/set-password.js
@@ -6,25 +6,25 @@ const Me = require('../queries/me')
 
 module.exports = async function setPassword (obj, { currentPassword, newPassword }, { log, session, state }) {
   if (!isLength(newPassword, { min: 6, max: 255 })) {
-    throw new ExposedError('Invalid password, minimum length 6 characters')
+    throw new ExposedError('Invalid password, minimum length 6 characters', 'INVALID_PASSWORD')
   }
 
   const [checkResult] = await state.dbPool('bm_web_users')
     .select('player_id', 'password')
     .where('player_id', session.playerId)
 
-  if (!checkResult) throw new ExposedError('You do not have an account, please register')
+  if (!checkResult) throw new ExposedError('You do not have an account, please register', 'NO_ACCOUNT')
 
   // Only expect current password if player did not login via pin
   // as pin is 'forgot password' journey
   if (session.type !== 'pin') {
     if (!currentPassword || !isLength(currentPassword, { min: 6, max: 255 })) {
-      throw new ExposedError('Invalid password, minimum length 6 characters')
+      throw new ExposedError('Invalid password, minimum length 6 characters', 'INVALID_PASSWORD')
     }
 
     const match = await verify(checkResult.password, currentPassword)
 
-    if (!match) throw new ExposedError('Incorrect login details')
+    if (!match) throw new ExposedError('Incorrect login details', 'INCORRECT_LOGIN')
   }
 
   let commonPassword = 0
@@ -36,7 +36,13 @@ module.exports = async function setPassword (obj, { currentPassword, newPassword
   }
 
   if (commonPassword > 5) {
-    throw new ExposedError(`This password isn't safe to use as it's appeared in ${new Intl.NumberFormat().format(commonPassword)} known data breaches`)
+    const formatted = new Intl.NumberFormat().format(commonPassword)
+
+    throw new ExposedError(
+      `This password isn't safe to use as it's appeared in ${formatted} known data breaches`,
+      'PASSWORD_COMPROMISED',
+      { count: commonPassword }
+    )
   }
 
   const encodedHash = await hash(newPassword)

--- a/server/graphql/resolvers/mutations/set-password.js
+++ b/server/graphql/resolvers/mutations/set-password.js
@@ -6,7 +6,7 @@ const Me = require('../queries/me')
 
 module.exports = async function setPassword (obj, { currentPassword, newPassword }, { log, session, state }) {
   if (!isLength(newPassword, { min: 6, max: 255 })) {
-    throw new ExposedError('Invalid password, minimum length 6 characters', 'INVALID_PASSWORD')
+    throw new ExposedError('Invalid password, minimum length 6 characters', 'INVALID_PASSWORD_LENGTH', { minLength: 6 })
   }
 
   const [checkResult] = await state.dbPool('bm_web_users')
@@ -19,7 +19,7 @@ module.exports = async function setPassword (obj, { currentPassword, newPassword
   // as pin is 'forgot password' journey
   if (session.type !== 'pin') {
     if (!currentPassword || !isLength(currentPassword, { min: 6, max: 255 })) {
-      throw new ExposedError('Invalid password, minimum length 6 characters', 'INVALID_PASSWORD')
+      throw new ExposedError('Invalid password, minimum length 6 characters', 'INVALID_PASSWORD_LENGTH', { minLength: 6 })
     }
 
     const match = await verify(checkResult.password, currentPassword)

--- a/server/graphql/resolvers/mutations/set-roles.js
+++ b/server/graphql/resolvers/mutations/set-roles.js
@@ -10,11 +10,11 @@ module.exports = async function setRoles (obj, { player, input: { roles, serverR
   const dataRoles = await state.dbPool('bm_web_roles').whereIn('role_id', roleIds)
 
   if (dataRoles.filter(Boolean).length !== roleIds.length) {
-    throw new ExposedError('Invalid role provided')
+    throw new ExposedError('Invalid role provided', 'INVALID_INPUT')
   }
 
   serverRoles.forEach(role => {
-    if (!state.serversPool.get(role.server.id)) throw new ExposedError(`Server ${role.server.id} does not exist`)
+    if (!state.serversPool.get(role.server.id)) throw new ExposedError(`Server ${role.server.id} does not exist`, 'SERVER_NOT_FOUND')
   })
 
   const globalRoles = roles.map(role => ({ role_id: role.id, player_id: player }))

--- a/server/graphql/resolvers/mutations/update-notification-rule.js
+++ b/server/graphql/resolvers/mutations/update-notification-rule.js
@@ -4,19 +4,19 @@ const notificationRule = require('../queries/notification-rule')
 module.exports = async function updateNotificationRule (obj, { id, input: { type, roles, serverId } }, { state }, info) {
   const data = await notificationRule(obj, { id }, { state }, info)
 
-  if (!data) throw new ExposedError(`Notification rule ${id} does not exist`)
+  if (!data) throw new ExposedError(`Notification rule ${id} does not exist`, 'NOTIFICATION_NOT_FOUND')
 
   if (serverId) {
     const server = state.serversPool.get(serverId)
 
-    if (!server) throw new ExposedError(`Server ${serverId} does not exist`)
+    if (!server) throw new ExposedError(`Server ${serverId} does not exist`, 'SERVER_NOT_FOUND')
   }
 
   const roleIds = roles.map(role => role.id)
   const results = await state.dbPool('bm_web_roles').select('role_id').whereIn('role_id', roleIds)
 
   if (results.length !== roleIds.length) {
-    throw new ExposedError('Invalid role')
+    throw new ExposedError('Invalid role', 'INVALID_INPUT')
   }
 
   await state.dbPool.transaction(async trx => {

--- a/server/graphql/resolvers/mutations/update-player-ban.js
+++ b/server/graphql/resolvers/mutations/update-player-ban.js
@@ -4,11 +4,11 @@ const ExposedError = require('../../../data/exposed-error')
 module.exports = async function updatePlayerBan (obj, { id, serverId, input }, { state }, info) {
   const server = state.serversPool.get(serverId)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const data = await playerBan(obj, { id, serverId }, { state }, info)
 
-  if (!data) throw new ExposedError(`Player ban ${id} does not exist`)
+  if (!data) throw new ExposedError(`Player ban ${id} does not exist`, 'BAN_NOT_FOUND')
 
   const table = server.config.tables.playerBans
 

--- a/server/graphql/resolvers/mutations/update-player-mute.js
+++ b/server/graphql/resolvers/mutations/update-player-mute.js
@@ -4,11 +4,11 @@ const ExposedError = require('../../../data/exposed-error')
 module.exports = async function updatePlayerMute (obj, { id, serverId, input }, { state }, info) {
   const server = state.serversPool.get(serverId)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const data = await playerMute(obj, { id, serverId }, { state }, info)
 
-  if (!data) throw new ExposedError(`Player mute ${id} does not exist`)
+  if (!data) throw new ExposedError(`Player mute ${id} does not exist`, 'MUTE_NOT_FOUND')
 
   const table = server.config.tables.playerMutes
 

--- a/server/graphql/resolvers/mutations/update-player-note.js
+++ b/server/graphql/resolvers/mutations/update-player-note.js
@@ -4,11 +4,11 @@ const ExposedError = require('../../../data/exposed-error')
 module.exports = async function updatePlayerNote (obj, { id, serverId, input }, { state }, info) {
   const server = state.serversPool.get(serverId)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   let data = await PlayerNote(obj, { id, serverId }, { state }, info)
 
-  if (!data) throw new ExposedError(`Player note ${id} does not exist`)
+  if (!data) throw new ExposedError(`Player note ${id} does not exist`, 'NOTE_NOT_FOUND')
 
   const updateData = { message: input.message }
   const table = server.config.tables.playerNotes

--- a/server/graphql/resolvers/mutations/update-player-warnings.js
+++ b/server/graphql/resolvers/mutations/update-player-warnings.js
@@ -4,11 +4,11 @@ const ExposedError = require('../../../data/exposed-error')
 module.exports = async function updatePlayerWarning (obj, { id, serverId, input }, { state }, info) {
   const server = state.serversPool.get(serverId)
 
-  if (!server) throw new ExposedError('Server does not exist')
+  if (!server) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   let data = await playerWarning(obj, { id, serverId }, { state }, info)
 
-  if (!data) throw new ExposedError(`Player warning ${id} does not exist`)
+  if (!data) throw new ExposedError(`Player warning ${id} does not exist`, 'WARNING_NOT_FOUND')
 
   const table = server.config.tables.playerWarnings
   const updateData = { points: input.points, expires: input.expires, reason: input.reason }

--- a/server/graphql/resolvers/mutations/update-role.js
+++ b/server/graphql/resolvers/mutations/update-role.js
@@ -2,7 +2,7 @@ const ExposedError = require('../../../data/exposed-error')
 const role = require('../queries/role')
 
 module.exports = async function updateRole (obj, { id, input: { name, parent, resources } }, { state }, info) {
-  if (id < 4 && parent) throw new ExposedError('Default roles can not have a parent')
+  if (id < 4 && parent) throw new ExposedError('Default roles can not have a parent', 'DEFAULT_ROLE_PARENT_FORBIDDEN')
 
   await state.dbPool('bm_web_roles').update({ name, parent_role_id: parent || null }).where({ role_id: id })
 

--- a/server/graphql/resolvers/mutations/update-server.js
+++ b/server/graphql/resolvers/mutations/update-server.js
@@ -6,7 +6,7 @@ const ExposedError = require('../../../data/exposed-error')
 const { tables } = require('../../../data/tables')
 
 module.exports = async function updateServer (obj, { id, input }, { log, state }) {
-  if (!state.serversPool.has(id)) throw new ExposedError('Server not found')
+  if (!state.serversPool.has(id)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
 
   const serverExists = await state.dbPool('bm_web_servers')
     .select('id')
@@ -14,7 +14,7 @@ module.exports = async function updateServer (obj, { id, input }, { log, state }
     .first()
 
   if (serverExists && serverExists.id !== id) {
-    throw new ExposedError('A server with this name already exists')
+    throw new ExposedError('A server with this name already exists', 'ALREADY_EXISTS')
   }
 
   // @TODO Check if connection details changed to avoid needing password to change server name
@@ -23,7 +23,7 @@ module.exports = async function updateServer (obj, { id, input }, { log, state }
   try {
     conn = await createConnection(pick(input, ['host', 'port', 'database', 'user', 'password']))
   } catch (e) {
-    throw new ExposedError(e.message)
+    throw new ExposedError(e.message, 'DB_CONNECTION_ERROR')
   }
 
   const tableNames = Object.keys(tables)
@@ -39,7 +39,7 @@ module.exports = async function updateServer (obj, { id, input }, { log, state }
 
   if (tablesMissing.length) {
     await conn.end()
-    throw new ExposedError(`Tables do not exist in the database: ${tablesMissing.join(', ')}`)
+    throw new ExposedError(`Tables do not exist in the database: ${tablesMissing.join(', ')}`, 'MISSING_DATABASE_TABLES')
   }
 
   const [[exists]] = await conn.query(
@@ -49,7 +49,7 @@ module.exports = async function updateServer (obj, { id, input }, { log, state }
   await conn.end()
 
   if (!exists) {
-    throw new ExposedError(`Console UUID not found in ${input.tables.players} table`)
+    throw new ExposedError(`Console UUID not found in ${input.tables.players} table`, 'CONSOLE_UUID_NOT_FOUND')
   }
 
   const rawPassword = input.password

--- a/server/graphql/resolvers/mutations/update-webhook.js
+++ b/server/graphql/resolvers/mutations/update-webhook.js
@@ -4,12 +4,12 @@ const webhook = require('../queries/webhook')
 module.exports = async function updateWebhook (obj, { id, input }, { state }, info) {
   const data = await webhook(obj, { id }, { state }, info)
 
-  if (!data) throw new ExposedError(`Webhook ${id} does not exist`)
+  if (!data) throw new ExposedError(`Webhook ${id} does not exist`, 'WEBHOOK_NOT_FOUND')
 
   if (input.serverId) {
     const server = state.serversPool.get(input.serverId)
 
-    if (!server) throw new ExposedError(`Server ${input.serverId} does not exist`)
+    if (!server) throw new ExposedError(`Server ${input.serverId} does not exist`, 'SERVER_NOT_FOUND')
   }
 
   await state.dbPool('bm_web_webhooks')

--- a/server/graphql/resolvers/queries/appeal-comment.js
+++ b/server/graphql/resolvers/queries/appeal-comment.js
@@ -17,7 +17,7 @@ module.exports = async function appealComment (obj, { id }, { state }, info) {
     .where(`${table}.id`, id)
     .first()
 
-  if (!data) throw new ExposedError('Appeal comment not found')
+  if (!data) throw new ExposedError('Appeal comment not found', 'APPEAL_COMMENT_NOT_FOUND')
 
   if (!state.acl.hasServerPermission(data.server_id, 'player.appeals', 'view.any')) {
     // We need to perform some permission checks
@@ -25,14 +25,14 @@ module.exports = async function appealComment (obj, { id }, { state }, info) {
       .select('actor_id', 'assignee_id')
       .where({ id: data.appeal_id })
 
-    if (!aclCheck) throw new ExposedError('Appeal not found')
+    if (!aclCheck) throw new ExposedError('Appeal not found', 'APPEAL_NOT_FOUND')
 
     const canView = (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'view.own') && state.acl.owns(aclCheck.actor_id)) ||
       (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'view.assigned') && state.acl.owns(aclCheck.assignee_id))
 
     if (!canView) {
       throw new ExposedError(
-        'You do not have permission to perform this action, please contact your server administrator')
+        'You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
     }
   }
 

--- a/server/graphql/resolvers/queries/appeal.js
+++ b/server/graphql/resolvers/queries/appeal.js
@@ -14,7 +14,7 @@ module.exports = async function appeal (obj, { id }, { session, state }, info) {
     .leftJoin('bm_web_appeal_states AS states', 'states.id', `${table}.state_id`)
     .first()
 
-  if (!data) throw new ExposedError(`Appeal ${id} does not exist`)
+  if (!data) throw new ExposedError(`Appeal ${id} does not exist`, 'APPEAL_NOT_FOUND')
 
   if (!state.acl.hasServerPermission(data.server_id, 'player.appeals', 'view.any')) {
     const canView = (state.acl.hasServerPermission(data.server_id, 'player.appeals', 'view.own') && state.acl.owns(data.actor_id)) ||
@@ -22,7 +22,7 @@ module.exports = async function appeal (obj, { id }, { session, state }, info) {
 
     if (!canView) {
       throw new ExposedError(
-        'You do not have permission to perform this action, please contact your server administrator')
+        'You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
     }
   }
 

--- a/server/graphql/resolvers/queries/list-appeal-comments.js
+++ b/server/graphql/resolvers/queries/list-appeal-comments.js
@@ -11,7 +11,7 @@ module.exports = async function listPlayerAppealComments (obj, { id, actor, orde
     .where({ id })
     .first()
 
-  if (!appeal) throw new ExposedError(`Appeal ${id} does not exist`)
+  if (!appeal) throw new ExposedError(`Appeal ${id} does not exist`, 'APPEAL_NOT_FOUND')
 
   if (!state.acl.hasServerPermission(appeal.server_id, 'player.appeals', 'view.any')) {
     if (!session || !session.playerId) return { total: 0, records: [] }

--- a/server/graphql/resolvers/queries/list-appeals.js
+++ b/server/graphql/resolvers/queries/list-appeals.js
@@ -6,8 +6,8 @@ const viewPerms = [
 ]
 
 module.exports = async function listPlayerAppeals (obj, { serverId, actor, assigned, state: stateId, limit, offset, order }, { session, state }, info) {
-  if (serverId && !state.serversPool.has(serverId)) throw new ExposedError('Server does not exist')
-  if (limit > 50) throw new ExposedError('Limit too large')
+  if (serverId && !state.serversPool.has(serverId)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
+  if (limit > 50) throw new ExposedError('Limit too large', 'LIMIT_TOO_LARGE')
 
   const data = {}
   const aclFilter = []

--- a/server/graphql/resolvers/queries/list-notification-rules.js
+++ b/server/graphql/resolvers/queries/list-notification-rules.js
@@ -2,7 +2,7 @@ const { parseResolveInfo, simplifyParsedResolveInfoFragmentWithType } = require(
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function listNotificationRules (obj, { limit, offset }, { session, state }, info) {
-  if (limit > 50) throw new ExposedError('Limit too large')
+  if (limit > 50) throw new ExposedError('Limit too large', 'LIMIT_TOO_LARGE')
 
   const parsedResolveInfoFragment = parseResolveInfo(info)
   const { fields } = simplifyParsedResolveInfoFragmentWithType(parsedResolveInfoFragment, info.returnType)

--- a/server/graphql/resolvers/queries/list-notifications.js
+++ b/server/graphql/resolvers/queries/list-notifications.js
@@ -3,7 +3,7 @@ const ExposedError = require('../../../data/exposed-error')
 const { getNotificationType, getNotificationState } = require('../../../data/notification')
 
 module.exports = async function listNotifications (obj, { limit, offset }, { session, state }, info) {
-  if (limit > 50) throw new ExposedError('Limit too large')
+  if (limit > 50) throw new ExposedError('Limit too large', 'LIMIT_TOO_LARGE')
 
   const data = {}
   const filter = state.dbPool('bm_web_notifications AS n1')

--- a/server/graphql/resolvers/queries/list-player-punishment-records.js
+++ b/server/graphql/resolvers/queries/list-player-punishment-records.js
@@ -26,8 +26,8 @@ const defaultTypes = {
 }
 
 module.exports = async function listPlayerPunishmentRecords (obj, { serverId, actor, player, type, order }, { state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist')
-  if (!defaultTypes[type]) throw new ExposedError('Invalid type')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
+  if (!defaultTypes[type]) throw new ExposedError('Invalid type', 'INVALID_INPUT')
 
   const server = state.serversPool.get(serverId)
   const typeInfo = defaultTypes[type]

--- a/server/graphql/resolvers/queries/list-reports-comments.js
+++ b/server/graphql/resolvers/queries/list-reports-comments.js
@@ -8,7 +8,7 @@ const viewPerms = [
 ]
 
 module.exports = async function listPlayerReportComments (obj, { serverId, report, actor, order }, { session, state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
   if (!state.acl.hasServerPermission(serverId, 'player.reports', 'view.any')) {
     if (!session || !session.playerId) return { total: 0, records: [] }
 

--- a/server/graphql/resolvers/queries/list-reports.js
+++ b/server/graphql/resolvers/queries/list-reports.js
@@ -9,8 +9,8 @@ const viewPerms = [
 ]
 
 module.exports = async function listPlayerReports (obj, { serverId, actor, assigned, player, state: stateId, limit, offset, order }, { session, state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist')
-  if (limit > 50) throw new ExposedError('Limit too large')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
+  if (limit > 50) throw new ExposedError('Limit too large', 'LIMIT_TOO_LARGE')
 
   const data = { server: await getServer(obj, { id: serverId }, { state }, info) }
   const aclFilter = []

--- a/server/graphql/resolvers/queries/list-session-history.js
+++ b/server/graphql/resolvers/queries/list-session-history.js
@@ -4,8 +4,8 @@ const ExposedError = require('../../../data/exposed-error')
 
 // eslint-disable-next-line complexity
 module.exports = async function listPlayerSessionHistory (obj, { serverId, player, limit, offset, order = 'leave_DESC' }, { state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist')
-  if (limit > 50) throw new ExposedError('Limit too large')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
+  if (limit > 50) throw new ExposedError('Limit too large', 'LIMIT_TOO_LARGE')
 
   const server = state.serversPool.get(serverId)
   const totalQuery = server.pool(server.config.tables.playerHistory)
@@ -17,7 +17,7 @@ module.exports = async function listPlayerSessionHistory (obj, { serverId, playe
 
   const [{ total }] = await totalQuery
 
-  if (offset > total) throw new ExposedError('Offset greater than total')
+  if (offset > total) throw new ExposedError('Offset greater than total', 'OFFSET_OUT_OF_RANGE')
   if (total === 0) return { total, records: [] }
 
   const [col, type] = order.split('_')

--- a/server/graphql/resolvers/queries/list-users.js
+++ b/server/graphql/resolvers/queries/list-users.js
@@ -21,7 +21,7 @@ function handleFilters (query, { email, roles, serverRoles, dbPool }) {
 }
 
 module.exports = async function listUsers (obj, { player, email, role, serverRole, limit, offset }, { state: { dbPool } }, info) {
-  if (limit > 50) throw new ExposedError('Limit too large')
+  if (limit > 50) throw new ExposedError('Limit too large', 'LIMIT_TOO_LARGE')
 
   const filtered = !player && (!!email || !!role || !!serverRole)
 
@@ -85,7 +85,7 @@ module.exports = async function listUsers (obj, { player, email, role, serverRol
 
   if (total === 0) return { total, records: [] }
 
-  if (offset > total) throw new ExposedError('Offset greater than total')
+  if (offset > total) throw new ExposedError('Offset greater than total', 'OFFSET_OUT_OF_RANGE')
 
   const results = await query
   const userIds = results.map(row => row.player_id)

--- a/server/graphql/resolvers/queries/me.js
+++ b/server/graphql/resolvers/queries/me.js
@@ -17,7 +17,7 @@ module.exports = async function me (obj, info, { session, state, log }) {
     }
   }
 
-  const [checkResult] = await state.dbPool('bm_web_users').select('email').where('player_id', session.playerId)
+  const [checkResult] = await state.dbPool('bm_web_users').select('email', 'locale').where('player_id', session.playerId)
   let playerData = {}
 
   try {
@@ -32,6 +32,7 @@ module.exports = async function me (obj, info, { session, state, log }) {
     ...playerData,
     hasAccount: Boolean(checkResult?.email),
     email: checkResult ? checkResult.email : null,
+    locale: checkResult ? checkResult.locale : null,
     session: {
       type: session.type
     },

--- a/server/graphql/resolvers/queries/player-activity.js
+++ b/server/graphql/resolvers/queries/player-activity.js
@@ -1,10 +1,10 @@
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function playerActivity (obj, { serverId, actor, limit, createdStart, createdEnd, types }, { state: { loaders, serversPool } }, info) {
-  if (!serversPool.has(serverId)) throw new ExposedError('Server does not exist')
-  if (limit > 100) throw new ExposedError('Limit too large')
-  if (createdStart && createdEnd && createdStart > createdEnd) throw new ExposedError('Start must be before end')
-  if (!types.length) throw new ExposedError('Missing types')
+  if (!serversPool.has(serverId)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
+  if (limit > 100) throw new ExposedError('Limit too large', 'LIMIT_TOO_LARGE')
+  if (createdStart && createdEnd && createdStart > createdEnd) throw new ExposedError('Start must be before end', 'INVALID_INPUT')
+  if (!types.length) throw new ExposedError('Missing types', 'INVALID_INPUT')
 
   const filter = (query) => {
     if (actor) query.where('actor_id', actor)
@@ -144,7 +144,7 @@ module.exports = async function playerActivity (obj, { serverId, actor, limit, c
         return warningQuery()
     }
 
-    throw new ExposedError(`Unknown type ${type}`)
+    throw new ExposedError(`Unknown type ${type}`, 'INVALID_INPUT')
   }).flat()
 
   const data = await pool

--- a/server/graphql/resolvers/queries/player-ban.js
+++ b/server/graphql/resolvers/queries/player-ban.js
@@ -3,7 +3,7 @@ const { getSql } = require('../../utils')
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function playerBan (obj, { id, serverId }, { state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const fields = parseResolveInfo(info)

--- a/server/graphql/resolvers/queries/player-kick.js
+++ b/server/graphql/resolvers/queries/player-kick.js
@@ -3,7 +3,7 @@ const { getSql } = require('../../utils')
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function playerKick (obj, { id, serverId }, { state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const fields = parseResolveInfo(info)

--- a/server/graphql/resolvers/queries/player-mute.js
+++ b/server/graphql/resolvers/queries/player-mute.js
@@ -3,7 +3,7 @@ const { getSql } = require('../../utils')
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function playerMute (obj, { id, serverId }, { state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const fields = parseResolveInfo(info)

--- a/server/graphql/resolvers/queries/player-note.js
+++ b/server/graphql/resolvers/queries/player-note.js
@@ -3,7 +3,7 @@ const { getSql } = require('../../utils')
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function playerNote (obj, { id, serverId }, { state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const fields = parseResolveInfo(info)

--- a/server/graphql/resolvers/queries/player-warning.js
+++ b/server/graphql/resolvers/queries/player-warning.js
@@ -3,7 +3,7 @@ const { getSql } = require('../../utils')
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function playerWarning (obj, { id, serverId }, { state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const fields = parseResolveInfo(info)

--- a/server/graphql/resolvers/queries/report-comment.js
+++ b/server/graphql/resolvers/queries/report-comment.js
@@ -3,7 +3,7 @@ const { getSql } = require('../../utils')
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function reportComment (obj, { id, serverId }, { state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
 
@@ -22,7 +22,7 @@ module.exports = async function reportComment (obj, { id, serverId }, { state },
 
   const [data] = await query.exec()
 
-  if (!data) throw new ExposedError('Report comment not found')
+  if (!data) throw new ExposedError('Report comment not found', 'REPORT_COMMENT_NOT_FOUND')
 
   if (!state.acl.hasServerPermission(serverId, 'player.reports', 'view.any')) {
     // We need to perform some permission checks
@@ -30,7 +30,7 @@ module.exports = async function reportComment (obj, { id, serverId }, { state },
       .select('actor_id', 'player_id', 'assignee_id')
       .where({ id: data.report_id })
 
-    if (!aclCheck) throw new ExposedError('Report not found')
+    if (!aclCheck) throw new ExposedError('Report not found', 'REPORT_NOT_FOUND')
 
     const canView = (state.acl.hasServerPermission(serverId, 'player.reports', 'view.own') && state.acl.owns(aclCheck.actor_id)) ||
       (state.acl.hasServerPermission(serverId, 'player.reports', 'view.assigned') && state.acl.owns(aclCheck.assignee_id)) ||
@@ -38,7 +38,7 @@ module.exports = async function reportComment (obj, { id, serverId }, { state },
 
     if (!canView) {
       throw new ExposedError(
-        'You do not have permission to perform this action, please contact your server administrator')
+        'You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
     }
   }
 

--- a/server/graphql/resolvers/queries/report-states.js
+++ b/server/graphql/resolvers/queries/report-states.js
@@ -1,7 +1,7 @@
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function reportStates (obj, { serverId }, { state }) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server does not exist', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const results = await server.pool(server.config.tables.playerReportStates).select('id', 'name')

--- a/server/graphql/resolvers/queries/report.js
+++ b/server/graphql/resolvers/queries/report.js
@@ -5,7 +5,7 @@ const { getReportSubscription } = require('../../../data/notification/report')
 
 // eslint-disable-next-line complexity
 module.exports = async function report (obj, { id, serverId }, { session, state }, info) {
-  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found')
+  if (!state.serversPool.has(serverId)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
 
   const server = state.serversPool.get(serverId)
   const table = server.config.tables.playerReports
@@ -16,7 +16,7 @@ module.exports = async function report (obj, { id, serverId }, { session, state 
       .select('actor_id', 'player_id', 'assignee_id')
       .where({ id })
 
-    if (!aclCheck) throw new ExposedError('Report not found')
+    if (!aclCheck) throw new ExposedError('Report not found', 'REPORT_NOT_FOUND')
 
     const canView = (state.acl.hasServerPermission(serverId, 'player.reports', 'view.own') && state.acl.owns(aclCheck.actor_id)) ||
       (state.acl.hasServerPermission(serverId, 'player.reports', 'view.assigned') && state.acl.owns(aclCheck.assignee_id)) ||
@@ -24,7 +24,7 @@ module.exports = async function report (obj, { id, serverId }, { session, state 
 
     if (!canView) {
       throw new ExposedError(
-        'You do not have permission to perform this action, please contact your server administrator')
+        'You do not have permission to perform this action, please contact your server administrator', 'NO_PERMISSION')
     }
   }
 
@@ -41,7 +41,7 @@ module.exports = async function report (obj, { id, serverId }, { session, state 
 
   const [data] = await query.exec()
 
-  if (!data) throw new ExposedError('Report not found')
+  if (!data) throw new ExposedError('Report not found', 'REPORT_NOT_FOUND')
 
   // Add serverId to data for document resolver
   data.serverId = serverId

--- a/server/graphql/resolvers/queries/server-ban-stats.js
+++ b/server/graphql/resolvers/queries/server-ban-stats.js
@@ -2,8 +2,8 @@ const { getUnixTime, eachDayOfInterval, subDays } = require('date-fns')
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function serverBanStats (obj, { id, intervalDays }, { state: { serversPool }, log }) {
-  if (!serversPool.has(id)) throw new ExposedError('Server not found')
-  if (intervalDays > 90) throw new ExposedError('Maximum 90 intervalDays allowed')
+  if (!serversPool.has(id)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
+  if (intervalDays > 90) throw new ExposedError('Maximum 90 intervalDays allowed', 'INTERVAL_TOO_LARGE')
 
   const start = subDays(new Date(), intervalDays)
   const startUnixTime = getUnixTime(start)

--- a/server/graphql/resolvers/queries/server-mute-stats.js
+++ b/server/graphql/resolvers/queries/server-mute-stats.js
@@ -2,8 +2,8 @@ const { getUnixTime, eachDayOfInterval, subDays } = require('date-fns')
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function serverMuteStats (obj, { id, intervalDays }, { state: { serversPool }, log }) {
-  if (!serversPool.has(id)) throw new ExposedError('Server not found')
-  if (intervalDays > 90) throw new ExposedError('Maximum 90 intervalDays allowed')
+  if (!serversPool.has(id)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
+  if (intervalDays > 90) throw new ExposedError('Maximum 90 intervalDays allowed', 'INTERVAL_TOO_LARGE')
 
   const start = subDays(new Date(), intervalDays)
   const startUnixTime = getUnixTime(start)

--- a/server/graphql/resolvers/queries/server-report-stats.js
+++ b/server/graphql/resolvers/queries/server-report-stats.js
@@ -2,8 +2,8 @@ const { getUnixTime, eachDayOfInterval, subDays } = require('date-fns')
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function serverReportStats (obj, { id, intervalDays }, { state: { serversPool }, log }) {
-  if (!serversPool.has(id)) throw new ExposedError('Server not found')
-  if (intervalDays > 90) throw new ExposedError('Maximum 90 intervalDays allowed')
+  if (!serversPool.has(id)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
+  if (intervalDays > 90) throw new ExposedError('Maximum 90 intervalDays allowed', 'INTERVAL_TOO_LARGE')
 
   const start = subDays(new Date(), intervalDays)
   const startUnixTime = getUnixTime(start)

--- a/server/graphql/resolvers/queries/server-warning-stats.js
+++ b/server/graphql/resolvers/queries/server-warning-stats.js
@@ -2,8 +2,8 @@ const { getUnixTime, eachDayOfInterval, subDays } = require('date-fns')
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function serverWarningStats (obj, { id, intervalDays }, { state: { serversPool }, log }) {
-  if (!serversPool.has(id)) throw new ExposedError('Server not found')
-  if (intervalDays > 90) throw new ExposedError('Maximum 90 intervalDays allowed')
+  if (!serversPool.has(id)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
+  if (intervalDays > 90) throw new ExposedError('Maximum 90 intervalDays allowed', 'INTERVAL_TOO_LARGE')
 
   const start = subDays(new Date(), intervalDays)
   const startUnixTime = getUnixTime(start)

--- a/server/graphql/resolvers/queries/server.js
+++ b/server/graphql/resolvers/queries/server.js
@@ -1,7 +1,7 @@
 const ExposedError = require('../../../data/exposed-error')
 
 module.exports = async function server (obj, { id }, { state: { serversPool }, log }) {
-  if (!serversPool.has(id)) throw new ExposedError('Server not found')
+  if (!serversPool.has(id)) throw new ExposedError('Server not found', 'SERVER_NOT_FOUND')
 
   const server = Object.assign({}, serversPool.get(id).config)
 

--- a/server/graphql/schema.js
+++ b/server/graphql/schema.js
@@ -47,14 +47,36 @@ module.exports = ({ logger }) => {
     }),
     formatError (error) {
       const originalError = findOriginalError(error)
+      const code = originalError?.extensions?.code
 
-      if (originalError?.extensions?.code === 'ERR_EXPOSED' || originalError?.extensions?.code === 'BAD_USER_INPUT') {
-        return originalError
+      if (code === 'ERR_EXPOSED') {
+        const meta = originalError.extensions.meta || originalError.meta
+
+        return {
+          message: originalError.message,
+          extensions: {
+            code: 'ERR_EXPOSED',
+            appCode: originalError.extensions.appCode || originalError.code || 'UNKNOWN',
+            ...(meta ? { meta } : {})
+          }
+        }
+      }
+
+      if (code === 'BAD_USER_INPUT') {
+        return {
+          message: originalError.message,
+          extensions: {
+            code: 'BAD_USER_INPUT'
+          }
+        }
       }
 
       logger.error(originalError.stack ? originalError.stack : originalError)
 
-      return { message: 'Internal Server Error' }
+      return {
+        message: 'Internal Server Error',
+        extensions: { code: 'INTERNAL_SERVER_ERROR', appCode: 'INTERNAL' }
+      }
     },
     plugins: [
       createApollo4QueryValidationPlugin(),

--- a/server/graphql/types.js
+++ b/server/graphql/types.js
@@ -395,6 +395,7 @@ type Me {
   id: UUID
   name: String
   email: String
+  locale: String
   hasAccount: Boolean
   session: PlayerSession
   resources: [Resources!]
@@ -920,6 +921,7 @@ type Mutation {
 
   setPassword(currentPassword: String, newPassword: String!): Me! @allowIfLoggedIn
   setEmail(currentPassword: String!, email: String!): Me! @allowIfLoggedIn
+  setLocale(locale: String!): Me! @allowIfLoggedIn
 
   createNotificationRule(input: NotificationRuleInput!): NotificationRule! @allowIf(resource: "servers", permission: "manage")
   updateNotificationRule(id: ID!, input: NotificationRuleInput!): NotificationRule! @allowIf(resource: "servers", permission: "manage")

--- a/server/routes/notifications.js
+++ b/server/routes/notifications.js
@@ -4,10 +4,10 @@ module.exports = async function (ctx) {
   const { request: { params }, session, state, throw: throwError } = ctx
 
   if (typeof params.id !== 'string' || params.id.length > 22) {
-    return throwError(400, 'Invalid notification ID')
+    return throwError(400, 'Invalid notification ID', { code: 'INVALID_INPUT' })
   }
 
-  if (!session || !session.playerId) return throwError(400, 'You are not logged in')
+  if (!session || !session.playerId) return throwError(400, 'You are not logged in', { code: 'NOT_LOGGED_IN' })
 
   const notification = await state.dbPool('bm_web_notifications')
     .select('type', 'server_id', 'report_id', 'comment_id', 'appeal_id', 'state_id')

--- a/server/routes/opengraph/player.js
+++ b/server/routes/opengraph/player.js
@@ -21,7 +21,7 @@ const ttl = 1 * 60 * 60 * 1000 // 1 hour
 module.exports = async function (ctx) {
   const { request: { params }, throw: throwError, state, log } = ctx
 
-  if (!isUUID(params.id)) return throwError(400, 'Invalid UUID')
+  if (!isUUID(params.id)) return throwError(400, 'Invalid UUID', { code: 'INVALID_INPUT' })
 
   try {
     const file = await stat(path.join(publicDir, `images/opengraph/cache/player-${params.id}.png`))
@@ -37,7 +37,7 @@ module.exports = async function (ctx) {
   const playerId = parse(params.id, Buffer.alloc(16))
   const player = await state.loaders.player.load({ id: playerId, fields: ['name'] })
 
-  if (!player) return throwError(404, 'Player not found')
+  if (!player) return throwError(404, 'Player not found', { code: 'PLAYER_NOT_FOUND' })
 
   const data = await playerStatistics({}, { player: playerId }, { state })
 

--- a/server/routes/register.js
+++ b/server/routes/register.js
@@ -4,20 +4,24 @@ const { pwnedPassword } = require('hibp')
 
 // eslint-disable-next-line complexity
 module.exports = async function ({ request: { body }, throw: throwError, response, session, state }) {
-  if (!session || !session.playerId) return throwError(400, 'You are not logged in')
+  if (!session || !session.playerId) return throwError(400, 'You are not logged in', { code: 'NOT_LOGGED_IN' })
 
-  if (typeof body.email !== 'string') return throwError(400, 'Invalid email type')
-  if (!isEmail(body.email)) return throwError(400, 'Invalid email address')
+  if (typeof body.email !== 'string') return throwError(400, 'Invalid email type', { code: 'INVALID_EMAIL' })
+  if (!isEmail(body.email)) return throwError(400, 'Invalid email address', { code: 'INVALID_EMAIL' })
 
-  if (typeof body.password !== 'string') return throwError(400, 'Invalid password type')
+  if (typeof body.password !== 'string') return throwError(400, 'Invalid password type', { code: 'INVALID_PASSWORD' })
   if (!isLength(body.password, { min: 6, max: 255 })) {
-    return throwError(400, 'Invalid password, minimum length 6 characters')
+    return throwError(400, 'Invalid password, minimum length 6 characters', { code: 'INVALID_PASSWORD' })
   }
 
   const commonPassword = await pwnedPassword(body.password)
 
   if (commonPassword > 5) {
-    return throwError(400, `This password isn't safe to use as it's appeared in ${new Intl.NumberFormat().format(commonPassword)} known data breaches`)
+    const formatted = new Intl.NumberFormat().format(commonPassword)
+    return throwError(400, `This password isn't safe to use as it's appeared in ${formatted} known data breaches`, {
+      code: 'PASSWORD_BREACHED',
+      meta: { count: commonPassword }
+    })
   }
 
   const checkResult = await state.dbPool('bm_web_users')
@@ -25,13 +29,13 @@ module.exports = async function ({ request: { body }, throw: throwError, respons
     .where('player_id', session.playerId)
     .first()
 
-  if (checkResult && checkResult.email) return throwError(400, 'You already have an account')
+  if (checkResult && checkResult.email) return throwError(400, 'You already have an account', { code: 'EMAIL_IN_USE' })
 
   const [emailResult] = await state.dbPool('bm_web_users')
     .select('email')
     .where('email', body.email)
 
-  if (emailResult) return throwError(400, 'You already have an account')
+  if (emailResult) return throwError(400, 'You already have an account', { code: 'EMAIL_IN_USE' })
 
   const encodedHash = await hash(body.password)
 

--- a/server/routes/register.js
+++ b/server/routes/register.js
@@ -11,7 +11,10 @@ module.exports = async function ({ request: { body }, throw: throwError, respons
 
   if (typeof body.password !== 'string') return throwError(400, 'Invalid password type', { code: 'INVALID_PASSWORD' })
   if (!isLength(body.password, { min: 6, max: 255 })) {
-    return throwError(400, 'Invalid password, minimum length 6 characters', { code: 'INVALID_PASSWORD' })
+    return throwError(400, 'Invalid password, minimum length 6 characters', {
+      code: 'INVALID_PASSWORD_LENGTH',
+      meta: { minLength: 6 }
+    })
   }
 
   const commonPassword = await pwnedPassword(body.password)

--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -51,7 +51,10 @@ async function handlePasswordLogin (ctx, { limiterSlowBruteByIP, limiterConsecut
 
   if (typeof request.body.password !== 'string') return throwError(400, 'Invalid password type', { code: 'INVALID_PASSWORD' })
   if (!isLength(request.body.password, { min: 6, max: 255 })) {
-    return throwError(400, 'Invalid password, minimum length 6 characters', { code: 'INVALID_PASSWORD' })
+    return throwError(400, 'Invalid password, minimum length 6 characters', {
+      code: 'INVALID_PASSWORD_LENGTH',
+      meta: { minLength: 6 }
+    })
   }
 
   const ipAddr = requestIp.getClientIp(ctx.request)

--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -46,12 +46,12 @@ module.exports = (dbPool) => {
 async function handlePasswordLogin (ctx, { limiterSlowBruteByIP, limiterConsecutiveFailsByUsernameAndIP }) {
   const { response, throw: throwError, request, state } = ctx
 
-  if (typeof request.body.email !== 'string') return throwError(400, 'Invalid email type')
-  if (!isEmail(request.body.email)) return throwError(400, 'Invalid email address')
+  if (typeof request.body.email !== 'string') return throwError(400, 'Invalid email type', { code: 'INVALID_EMAIL' })
+  if (!isEmail(request.body.email)) return throwError(400, 'Invalid email address', { code: 'INVALID_EMAIL' })
 
-  if (typeof request.body.password !== 'string') return throwError(400, 'Invalid password type')
+  if (typeof request.body.password !== 'string') return throwError(400, 'Invalid password type', { code: 'INVALID_PASSWORD' })
   if (!isLength(request.body.password, { min: 6, max: 255 })) {
-    return throwError(400, 'Invalid password, minimum length 6 characters')
+    return throwError(400, 'Invalid password, minimum length 6 characters', { code: 'INVALID_PASSWORD' })
   }
 
   const ipAddr = requestIp.getClientIp(ctx.request)
@@ -72,7 +72,7 @@ async function handlePasswordLogin (ctx, { limiterSlowBruteByIP, limiterConsecut
   }
 
   if (retrySecs > 0) {
-    return throwError(429, 'Too many requests')
+    return throwError(429, 'Too many requests', { code: 'RATE_LIMIT' })
   }
 
   const result = await state.dbPool('bm_web_users')
@@ -94,10 +94,10 @@ async function handlePasswordLogin (ctx, { limiterSlowBruteByIP, limiterConsecut
     } catch (e) {
       if (e instanceof Error) throw e
 
-      return throwError(429, 'Too many requests')
+      return throwError(429, 'Too many requests', { code: 'RATE_LIMIT' })
     }
 
-    return throwError(400, 'Incorrect login details')
+    return throwError(400, 'Incorrect login details', { code: 'INCORRECT_LOGIN' })
   }
 
   ctx.session = create(result.player_id, result.updated, 'password')
@@ -114,14 +114,14 @@ async function handlePasswordLogin (ctx, { limiterSlowBruteByIP, limiterConsecut
 async function handlePinLogin (ctx, { limiterSlowBruteByIP, limiterConsecutiveFailsByUsernameAndIP }) {
   const { response, throw: throwError, request, state } = ctx
 
-  if (typeof request.body.name !== 'string' || !isLength(request.body.name, { min: 2, max: 17 })) return throwError(400, 'Invalid name')
+  if (typeof request.body.name !== 'string' || !isLength(request.body.name, { min: 2, max: 17 })) return throwError(400, 'Invalid name', { code: 'INVALID_NAME' })
 
-  if (typeof request.body.pin !== 'string') return throwError(400, 'Invalid pin type')
-  if (!isLength(request.body.pin, { min: 6, max: 6 })) return throwError(400, 'Invalid pin, must be 6 characters')
+  if (typeof request.body.pin !== 'string') return throwError(400, 'Invalid pin type', { code: 'INVALID_PIN' })
+  if (!isLength(request.body.pin, { min: 6, max: 6 })) return throwError(400, 'Invalid pin, must be 6 characters', { code: 'INVALID_PIN' })
 
   const server = state.serversPool.get(request.body.serverId)
 
-  if (!server) return throwError(400, 'Server does not exist')
+  if (!server) return throwError(400, 'Server does not exist', { code: 'SERVER_NOT_FOUND' })
 
   const ipAddr = requestIp.getClientIp(ctx.request)
   const usernameIPkey = getUsernameIPkey(request.body.name, ipAddr)
@@ -141,7 +141,7 @@ async function handlePinLogin (ctx, { limiterSlowBruteByIP, limiterConsecutiveFa
   }
 
   if (retrySecs > 0) {
-    return throwError(429, 'Too many requests')
+    return throwError(429, 'Too many requests', { code: 'RATE_LIMIT' })
   }
 
   const { playerPins, players } = server.config.tables
@@ -170,10 +170,10 @@ async function handlePinLogin (ctx, { limiterSlowBruteByIP, limiterConsecutiveFa
     } catch (e) {
       if (e instanceof Error) throw e
 
-      return throwError(429, 'Too many requests')
+      return throwError(429, 'Too many requests', { code: 'RATE_LIMIT' })
     }
 
-    return throwError(400, 'Incorrect login details')
+    return throwError(400, 'Incorrect login details', { code: 'INCORRECT_LOGIN' })
   }
 
   await server.pool(playerPins)

--- a/server/routes/subscribe.js
+++ b/server/routes/subscribe.js
@@ -1,20 +1,20 @@
 module.exports = async function ({ request: { body }, throw: throwError, response, session, state }) {
-  if (!session || !session.playerId) return throwError(400, 'You are not logged in')
+  if (!session || !session.playerId) return throwError(400, 'You are not logged in', { code: 'NOT_LOGGED_IN' })
 
   if (!body || !body.endpoint || !body.keys || !body.keys.auth || !body.keys.p256dh) {
-    return throwError(400, 'Invalid request')
+    return throwError(400, 'Invalid request', { code: 'INVALID_INPUT' })
   }
 
-  if (typeof body.endpoint !== 'string') return throwError(400, 'Invalid endpoint type')
-  if (typeof body.keys.auth !== 'string') return throwError(400, 'Invalid auth type')
-  if (typeof body.keys.p256dh !== 'string') return throwError(400, 'Invalid p256dh type')
+  if (typeof body.endpoint !== 'string') return throwError(400, 'Invalid endpoint type', { code: 'INVALID_INPUT' })
+  if (typeof body.keys.auth !== 'string') return throwError(400, 'Invalid auth type', { code: 'INVALID_INPUT' })
+  if (typeof body.keys.p256dh !== 'string') return throwError(400, 'Invalid p256dh type', { code: 'INVALID_INPUT' })
 
   const [existingSubscription] = await state.dbPool('bm_web_notification_subscriptions')
     .select('id')
     .where('player_id', session.playerId)
     .where('endpoint', body.endpoint)
 
-  if (existingSubscription) return throwError(400, 'Subscription already exists')
+  if (existingSubscription) return throwError(400, 'Subscription already exists', { code: 'SUBSCRIPTION_EXISTS' })
 
   await state.dbPool('bm_web_notification_subscriptions')
     .insert({

--- a/server/routes/unsubscribe.js
+++ b/server/routes/unsubscribe.js
@@ -1,13 +1,13 @@
 module.exports = async function ({ request: { body }, throw: throwError, response, session, state }) {
-  if (!session || !session.playerId) return throwError(400, 'You are not logged in')
+  if (!session || !session.playerId) return throwError(400, 'You are not logged in', { code: 'NOT_LOGGED_IN' })
 
   if (!body || !body.endpoint || !body.keys || !body.keys.auth || !body.keys.p256dh) {
-    return throwError(400, 'Invalid request')
+    return throwError(400, 'Invalid request', { code: 'INVALID_INPUT' })
   }
 
-  if (typeof body.endpoint !== 'string') return throwError(400, 'Invalid endpoint type')
-  if (typeof body.keys.auth !== 'string') return throwError(400, 'Invalid auth type')
-  if (typeof body.keys.p256dh !== 'string') return throwError(400, 'Invalid p256dh type')
+  if (typeof body.endpoint !== 'string') return throwError(400, 'Invalid endpoint type', { code: 'INVALID_INPUT' })
+  if (typeof body.keys.auth !== 'string') return throwError(400, 'Invalid auth type', { code: 'INVALID_INPUT' })
+  if (typeof body.keys.p256dh !== 'string') return throwError(400, 'Invalid p256dh type', { code: 'INVALID_INPUT' })
 
   const [existingSubscription] = await state.dbPool('bm_web_notification_subscriptions')
     .select('id')

--- a/server/test/appealState.mutation.test.js
+++ b/server/test/appealState.mutation.test.js
@@ -41,8 +41,8 @@ describe('Mutation appealState', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow update.state.any', async () => {

--- a/server/test/appealSubscriptionState.mutation.test.js
+++ b/server/test/appealSubscriptionState.mutation.test.js
@@ -34,8 +34,8 @@ describe('Mutation appealSubscriptionState', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow view.any to subscribe', async () => {

--- a/server/test/assignAppeal.mutation.test.js
+++ b/server/test/assignAppeal.mutation.test.js
@@ -50,8 +50,8 @@ describe('Mutation assignAppeal', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow update.assign.any', async () => {

--- a/server/test/assignReport.mutation.test.js
+++ b/server/test/assignReport.mutation.test.js
@@ -44,8 +44,8 @@ describe('Mutation assignReport', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow update.assign.any', async () => {

--- a/server/test/createAppeal.mutation.test.js
+++ b/server/test/createAppeal.mutation.test.js
@@ -37,8 +37,8 @@ describe('Mutation create appeal', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should error if reason less than 20 characters', async () => {

--- a/server/test/createAppealComment.mutation.test.js
+++ b/server/test/createAppealComment.mutation.test.js
@@ -47,8 +47,8 @@ describe('Mutation createAppealComment', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow comment.any', async () => {

--- a/server/test/createReportComment.mutation.test.js
+++ b/server/test/createReportComment.mutation.test.js
@@ -44,8 +44,8 @@ describe('Mutation createReportComment', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow comment.any', async () => {

--- a/server/test/deleteDocument.mutation.test.js
+++ b/server/test/deleteDocument.mutation.test.js
@@ -34,8 +34,8 @@ describe('Mutation deleteDocument', () => {
 
     assert.strictEqual(statusCode, 200)
     assert(body.errors)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should error if document does not exist', async () => {

--- a/server/test/deletePlayerBan.mutation.test.js
+++ b/server/test/deletePlayerBan.mutation.test.js
@@ -35,8 +35,8 @@ describe('Mutation deletePlayerBan', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow delete.any', async () => {

--- a/server/test/deletePlayerBanRecord.mutation.test.js
+++ b/server/test/deletePlayerBanRecord.mutation.test.js
@@ -35,8 +35,8 @@ describe('Mutation deletePlayerBanRecordRecord', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow delete.any', async () => {

--- a/server/test/deletePlayerKick.mutation.test.js
+++ b/server/test/deletePlayerKick.mutation.test.js
@@ -35,8 +35,8 @@ describe('Mutation deletePlayerKick', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow delete.any', async () => {

--- a/server/test/deletePlayerMute.mutation.test.js
+++ b/server/test/deletePlayerMute.mutation.test.js
@@ -35,8 +35,8 @@ describe('Mutation deletePlayerMute', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow delete.any', async () => {

--- a/server/test/deletePlayerMuteRecord.mutation.test.js
+++ b/server/test/deletePlayerMuteRecord.mutation.test.js
@@ -35,8 +35,8 @@ describe('Mutation deletePlayerMuteRecordRecord', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow delete.any', async () => {

--- a/server/test/deletePlayerNote.mutation.test.js
+++ b/server/test/deletePlayerNote.mutation.test.js
@@ -35,8 +35,8 @@ describe('Mutation deletePlayerNote', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow delete.any', async () => {

--- a/server/test/deletePlayerWarning.mutation.test.js
+++ b/server/test/deletePlayerWarning.mutation.test.js
@@ -35,8 +35,8 @@ describe('Mutation deletePlayerWarning', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow delete.any', async () => {

--- a/server/test/deleteReportComment.mutation.test.js
+++ b/server/test/deleteReportComment.mutation.test.js
@@ -35,8 +35,8 @@ describe('Mutation deleteReportComment', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow comment.delete.any', async () => {

--- a/server/test/error-translation.test.js
+++ b/server/test/error-translation.test.js
@@ -1,0 +1,155 @@
+const assert = require('assert')
+const { translateRestError, translateGraphqlError } = require('../data/error-translation')
+
+const buildT = (catalog) => {
+  const fn = (key, vars = {}) => {
+    const template = catalog[key]
+    if (template === undefined) return key
+    return template.replace(/\{(\w+)\}/g, (_, name) => (name in vars ? String(vars[name]) : `{${name}}`))
+  }
+
+  fn.has = (key) => Object.prototype.hasOwnProperty.call(catalog, key)
+  return fn
+}
+
+describe('translateRestError', () => {
+  test('returns null for missing response data', () => {
+    const t = buildT({})
+    assert.strictEqual(translateRestError(t, null), null)
+    assert.strictEqual(translateRestError(t, undefined), null)
+  })
+
+  test('returns translated error when code matches catalog', () => {
+    const t = buildT({ 'errors.PASSWORD_BREACHED': 'Password breached {count} times' })
+    const err = translateRestError(t, { code: 'PASSWORD_BREACHED', meta: { count: 42 } })
+
+    assert.ok(err instanceof Error)
+    assert.strictEqual(err.message, 'Password breached 42 times')
+    assert.strictEqual(err.code, 'PASSWORD_BREACHED')
+    assert.deepStrictEqual(err.meta, { count: 42 })
+  })
+
+  test('falls back to server-supplied error when code is not in catalog', () => {
+    const t = buildT({})
+    const err = translateRestError(t, { code: 'WHATEVER', error: 'Something went wrong' })
+
+    assert.strictEqual(err.message, 'Something went wrong')
+    assert.strictEqual(err.code, 'WHATEVER')
+    assert.deepStrictEqual(err.meta, {})
+  })
+
+  test('falls back to "Unknown error" when both code and error are missing', () => {
+    const t = buildT({})
+    const err = translateRestError(t, {})
+
+    assert.strictEqual(err.message, 'Unknown error')
+  })
+
+  test('does not crash when meta is omitted', () => {
+    const t = buildT({ 'errors.X': 'X happened' })
+    const err = translateRestError(t, { code: 'X' })
+
+    assert.strictEqual(err.message, 'X happened')
+    assert.deepStrictEqual(err.meta, {})
+  })
+})
+
+describe('translateGraphqlError', () => {
+  test('returns input unchanged when source is falsy', () => {
+    const t = buildT({})
+    assert.strictEqual(translateGraphqlError(t, null), null)
+    assert.strictEqual(translateGraphqlError(t, undefined), undefined)
+  })
+
+  test('translates ExposedError with appCode + meta', () => {
+    const t = buildT({ 'errors.SERVER_NOT_FOUND': 'Server "{name}" not found' })
+    const result = translateGraphqlError(t, {
+      message: 'Server not found',
+      extensions: { code: 'ERR_EXPOSED', appCode: 'SERVER_NOT_FOUND', meta: { name: 'Hub' } }
+    })
+
+    assert.strictEqual(result, 'Server "Hub" not found')
+  })
+
+  test('falls back to source.message when appCode has no translation', () => {
+    const t = buildT({})
+    const result = translateGraphqlError(t, {
+      message: 'Original server message',
+      extensions: { code: 'ERR_EXPOSED', appCode: 'UNMAPPED_CODE' }
+    })
+
+    assert.strictEqual(result, 'Original server message')
+  })
+
+  test('does NOT translate INTERNAL_SERVER_ERROR (returns source.message)', () => {
+    const t = buildT({ 'errors.INTERNAL_SERVER_ERROR': 'Should not be used' })
+    const result = translateGraphqlError(t, {
+      message: 'Internal Server Error',
+      extensions: { code: 'INTERNAL_SERVER_ERROR' }
+    })
+
+    assert.strictEqual(result, 'Internal Server Error')
+  })
+
+  test('does NOT translate INTERNAL appCode (returns source.message)', () => {
+    const t = buildT({ 'errors.INTERNAL': 'Should not be used' })
+    const result = translateGraphqlError(t, {
+      message: 'Internal Server Error',
+      extensions: { code: 'INTERNAL_SERVER_ERROR', appCode: 'INTERNAL' }
+    })
+
+    assert.strictEqual(result, 'Internal Server Error')
+  })
+
+  test('does NOT translate BAD_USER_INPUT (returns source.message verbatim)', () => {
+    const t = buildT({ 'errors.BAD_USER_INPUT': 'should not be used' })
+    const result = translateGraphqlError(t, {
+      message: 'Must be at most 20 characters',
+      extensions: { code: 'BAD_USER_INPUT' }
+    })
+
+    assert.strictEqual(result, 'Must be at most 20 characters')
+  })
+
+  test('does NOT translate UNKNOWN appCode (returns source.message)', () => {
+    const t = buildT({ 'errors.UNKNOWN': 'Should not be used' })
+    const result = translateGraphqlError(t, {
+      message: 'A server error',
+      extensions: { code: 'ERR_EXPOSED', appCode: 'UNKNOWN' }
+    })
+
+    assert.strictEqual(result, 'A server error')
+  })
+
+  test('uses transportCode as appCode fallback when transport is not ERR_EXPOSED', () => {
+    const t = buildT({ 'errors.GRAPHQL_VALIDATION_FAILED': 'Validation failed' })
+    const result = translateGraphqlError(t, {
+      message: 'fallback msg',
+      extensions: { code: 'GRAPHQL_VALIDATION_FAILED' }
+    })
+
+    assert.strictEqual(result, 'Validation failed')
+  })
+
+  test('uses extensions.meta over root meta', () => {
+    const t = buildT({ 'errors.X': 'X={value}' })
+    const result = translateGraphqlError(t, {
+      message: 'fallback',
+      meta: { value: 'root' },
+      extensions: { code: 'ERR_EXPOSED', appCode: 'X', meta: { value: 'extensions' } }
+    })
+
+    assert.strictEqual(result, 'X=extensions')
+  })
+
+  test('falls back to root meta when extensions.meta is absent', () => {
+    const t = buildT({ 'errors.X': 'X={value}' })
+    const result = translateGraphqlError(t, {
+      message: 'fallback',
+      meta: { value: 'root' },
+      extensions: { code: 'ERR_EXPOSED', appCode: 'X' }
+    })
+
+    assert.strictEqual(result, 'X=root')
+  })
+})

--- a/server/test/formatError.test.js
+++ b/server/test/formatError.test.js
@@ -1,0 +1,140 @@
+const assert = require('assert')
+const supertest = require('supertest')
+const createApp = require('../app')
+const { createSetup, getAuthPassword } = require('./lib')
+
+describe('GraphQL formatError', () => {
+  let setup
+  let request
+
+  beforeAll(async () => {
+    setup = await createSetup()
+    const app = await createApp({ ...setup, disableUI: true })
+
+    request = supertest(app.callback())
+  }, 20000)
+
+  afterAll(async () => {
+    await setup.teardown()
+  })
+
+  test('should expose appCode for ExposedError thrown by resolver', async () => {
+    const cookie = await getAuthPassword(request, 'admin@banmanagement.com')
+    const { body, statusCode } = await request
+      .post('/graphql')
+      .set('Cookie', cookie)
+      .set('Accept', 'application/json')
+      .send({
+        query: `mutation setLocale {
+        setLocale(locale: "xx") {
+          id
+        }
+      }`
+      })
+
+    assert.strictEqual(statusCode, 200)
+    assert(body.errors)
+
+    const error = body.errors[0]
+
+    assert.strictEqual(error.extensions.code, 'ERR_EXPOSED')
+    assert.strictEqual(error.extensions.appCode, 'INVALID_LOCALE')
+  })
+
+  test('should expose NOT_LOGGED_IN appCode when @allowIfLoggedIn rejects', async () => {
+    const { body, statusCode } = await request
+      .post('/graphql')
+      .set('Accept', 'application/json')
+      .send({
+        query: `mutation setLocale {
+        setLocale(locale: "de") {
+          id
+        }
+      }`
+      })
+
+    assert.strictEqual(statusCode, 200)
+    assert(body.errors)
+
+    const error = body.errors[0]
+
+    assert.strictEqual(error.extensions.code, 'ERR_EXPOSED')
+    assert.strictEqual(error.extensions.appCode, 'NOT_LOGGED_IN')
+    assert.strictEqual(error.message, 'You are not logged in')
+  })
+
+  test('should expose meta when ExposedError carries meta', async () => {
+    const cookie = await getAuthPassword(request, 'admin@banmanagement.com')
+    const { body, statusCode } = await request
+      .post('/graphql')
+      .set('Cookie', cookie)
+      .set('Accept', 'application/json')
+      .send({
+        query: `mutation setLocale {
+        setLocale(locale: "fr") {
+          id
+        }
+      }`
+      })
+
+    assert.strictEqual(statusCode, 200)
+    assert(body.errors)
+
+    const error = body.errors[0]
+
+    assert.strictEqual(error.extensions.code, 'ERR_EXPOSED')
+    assert.strictEqual(error.extensions.appCode, 'INVALID_LOCALE')
+  })
+})
+
+describe('GraphQL formatError (unit)', () => {
+  let formatError
+
+  beforeAll(() => {
+    const config = require('../graphql/schema')({ logger: { error () {} } })
+    formatError = config.formatError
+  })
+
+  test('preserves explicit appCode on ExposedError', () => {
+    const original = new Error('boom')
+    original.extensions = { code: 'ERR_EXPOSED', appCode: 'CUSTOM_CODE', meta: { foo: 1 } }
+
+    const result = formatError({ originalError: original, message: 'boom' })
+
+    assert.deepStrictEqual(result, {
+      message: 'boom',
+      extensions: { code: 'ERR_EXPOSED', appCode: 'CUSTOM_CODE', meta: { foo: 1 } }
+    })
+  })
+
+  test('defaults appCode to UNKNOWN when ExposedError omits it', () => {
+    const original = new Error('boom')
+    original.extensions = { code: 'ERR_EXPOSED' }
+
+    const result = formatError({ originalError: original, message: 'boom' })
+
+    assert.strictEqual(result.extensions.appCode, 'UNKNOWN')
+  })
+
+  test('passes BAD_USER_INPUT through without overriding the original message', () => {
+    const original = new Error('Must be at most 20 characters')
+    original.extensions = { code: 'BAD_USER_INPUT' }
+
+    const result = formatError({ originalError: original, message: 'Must be at most 20 characters' })
+
+    assert.strictEqual(result.message, 'Must be at most 20 characters')
+    assert.strictEqual(result.extensions.code, 'BAD_USER_INPUT')
+    assert.strictEqual(result.extensions.appCode, undefined,
+      'BAD_USER_INPUT should NOT carry an appCode so the constraint message is shown verbatim')
+  })
+
+  test('maps unknown errors to INTERNAL_SERVER_ERROR / INTERNAL', () => {
+    const original = new Error('kaboom')
+
+    const result = formatError({ originalError: original, message: 'kaboom' })
+
+    assert.strictEqual(result.message, 'Internal Server Error')
+    assert.strictEqual(result.extensions.code, 'INTERNAL_SERVER_ERROR')
+    assert.strictEqual(result.extensions.appCode, 'INTERNAL')
+  })
+})

--- a/server/test/locale.test.js
+++ b/server/test/locale.test.js
@@ -1,0 +1,199 @@
+const assert = require('assert')
+const {
+  SUPPORTED_LOCALES,
+  DEFAULT_LOCALE,
+  LOCALE_COOKIE,
+  isSupportedLocale,
+  parseCookieHeader,
+  parseAcceptLanguage,
+  negotiateLocale,
+  negotiateLocaleFromRequest
+} = require('../data/locales')
+
+describe('Locale negotiation', () => {
+  describe('isSupportedLocale', () => {
+    test('returns true for supported locales', () => {
+      for (const locale of SUPPORTED_LOCALES) {
+        assert.strictEqual(isSupportedLocale(locale), true, `Expected ${locale} to be supported`)
+      }
+    })
+
+    test('returns false for unsupported locales', () => {
+      assert.strictEqual(isSupportedLocale('xx'), false)
+      assert.strictEqual(isSupportedLocale('fr-FR'), false)
+      assert.strictEqual(isSupportedLocale(''), false)
+    })
+
+    test('returns false for non-string values', () => {
+      assert.strictEqual(isSupportedLocale(null), false)
+      assert.strictEqual(isSupportedLocale(undefined), false)
+      assert.strictEqual(isSupportedLocale(123), false)
+      assert.strictEqual(isSupportedLocale({}), false)
+    })
+  })
+
+  describe('SUPPORTED_LOCALES', () => {
+    test('always includes en as default fallback', () => {
+      assert.ok(SUPPORTED_LOCALES.includes('en'))
+      assert.strictEqual(DEFAULT_LOCALE, 'en')
+    })
+
+    test('contains de translation locale', () => {
+      assert.ok(SUPPORTED_LOCALES.includes('de'))
+    })
+  })
+
+  describe('parseCookieHeader', () => {
+    test('extracts the named cookie value', () => {
+      const result = parseCookieHeader('foo=bar; bm_locale=de; baz=qux', LOCALE_COOKIE)
+
+      assert.strictEqual(result, 'de')
+    })
+
+    test('returns null when cookie missing', () => {
+      assert.strictEqual(parseCookieHeader('foo=bar', LOCALE_COOKIE), null)
+    })
+
+    test('returns null for empty/invalid input', () => {
+      assert.strictEqual(parseCookieHeader('', LOCALE_COOKIE), null)
+      assert.strictEqual(parseCookieHeader(null, LOCALE_COOKIE), null)
+      assert.strictEqual(parseCookieHeader(undefined, LOCALE_COOKIE), null)
+    })
+
+    test('decodes URI-encoded values', () => {
+      const result = parseCookieHeader('bm_locale=' + encodeURIComponent('de'), LOCALE_COOKIE)
+
+      assert.strictEqual(result, 'de')
+    })
+
+    test('skips malformed cookie segments', () => {
+      const result = parseCookieHeader('malformed; bm_locale=de', LOCALE_COOKIE)
+
+      assert.strictEqual(result, 'de')
+    })
+  })
+
+  describe('parseAcceptLanguage', () => {
+    test('parses simple accept-language', () => {
+      assert.deepStrictEqual(parseAcceptLanguage('en'), ['en'])
+    })
+
+    test('parses prioritised accept-language', () => {
+      assert.deepStrictEqual(
+        parseAcceptLanguage('de;q=0.8,en-GB;q=0.9,fr;q=0.7'),
+        ['en-gb', 'de', 'fr']
+      )
+    })
+
+    test('handles missing q (defaults to 1.0)', () => {
+      assert.deepStrictEqual(
+        parseAcceptLanguage('en-GB,de;q=0.5'),
+        ['en-gb', 'de']
+      )
+    })
+
+    test('returns empty array for invalid input', () => {
+      assert.deepStrictEqual(parseAcceptLanguage(''), [])
+      assert.deepStrictEqual(parseAcceptLanguage(null), [])
+      assert.deepStrictEqual(parseAcceptLanguage(undefined), [])
+    })
+  })
+
+  describe('negotiateLocale', () => {
+    test('user preference wins over cookie and accept-language', () => {
+      const result = negotiateLocale({
+        user: { locale: 'de' },
+        cookieValue: 'en',
+        acceptLanguage: 'fr,en'
+      })
+
+      assert.strictEqual(result, 'de')
+    })
+
+    test('cookie wins over accept-language when no user', () => {
+      const result = negotiateLocale({
+        cookieValue: 'de',
+        acceptLanguage: 'en'
+      })
+
+      assert.strictEqual(result, 'de')
+    })
+
+    test('falls back to accept-language when no cookie', () => {
+      const result = negotiateLocale({
+        acceptLanguage: 'de-DE,en;q=0.8'
+      })
+
+      assert.strictEqual(result, 'de')
+    })
+
+    test('falls back to DEFAULT_LOCALE when nothing matches', () => {
+      const result = negotiateLocale({
+        acceptLanguage: 'fr,it'
+      })
+
+      assert.strictEqual(result, DEFAULT_LOCALE)
+    })
+
+    test('ignores unsupported user.locale', () => {
+      const result = negotiateLocale({
+        user: { locale: 'xx' },
+        cookieValue: 'de'
+      })
+
+      assert.strictEqual(result, 'de')
+    })
+
+    test('ignores unsupported cookie value', () => {
+      const result = negotiateLocale({
+        cookieValue: 'xx',
+        acceptLanguage: 'de'
+      })
+
+      assert.strictEqual(result, 'de')
+    })
+
+    test('returns DEFAULT_LOCALE when no inputs provided', () => {
+      assert.strictEqual(negotiateLocale(), DEFAULT_LOCALE)
+      assert.strictEqual(negotiateLocale({}), DEFAULT_LOCALE)
+    })
+  })
+
+  describe('negotiateLocaleFromRequest', () => {
+    test('extracts locale from request cookies + headers', () => {
+      const req = {
+        headers: {
+          cookie: 'session=abc; bm_locale=de',
+          'accept-language': 'fr,en'
+        }
+      }
+
+      assert.strictEqual(negotiateLocaleFromRequest(req), 'de')
+    })
+
+    test('falls back to accept-language when no cookie', () => {
+      const req = {
+        headers: { 'accept-language': 'de-DE,en;q=0.8' }
+      }
+
+      assert.strictEqual(negotiateLocaleFromRequest(req), 'de')
+    })
+
+    test('falls back to DEFAULT_LOCALE on missing/empty req', () => {
+      assert.strictEqual(negotiateLocaleFromRequest(null), DEFAULT_LOCALE)
+      assert.strictEqual(negotiateLocaleFromRequest({}), DEFAULT_LOCALE)
+      assert.strictEqual(negotiateLocaleFromRequest({ headers: {} }), DEFAULT_LOCALE)
+    })
+
+    test('user override takes precedence over cookie', () => {
+      const req = {
+        headers: {
+          cookie: 'bm_locale=en',
+          'accept-language': 'fr'
+        }
+      }
+
+      assert.strictEqual(negotiateLocaleFromRequest(req, { locale: 'de' }), 'de')
+    })
+  })
+})

--- a/server/test/reportState.mutation.test.js
+++ b/server/test/reportState.mutation.test.js
@@ -40,8 +40,8 @@ describe('Mutation reportState', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow update.state.any', async () => {

--- a/server/test/reportSubscriptionState.mutation.test.js
+++ b/server/test/reportSubscriptionState.mutation.test.js
@@ -35,8 +35,8 @@ describe('Mutation reportSubscriptionState', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow view.any to subscribe', async () => {

--- a/server/test/resolveAppealDeleteBan.mutation.test.js
+++ b/server/test/resolveAppealDeleteBan.mutation.test.js
@@ -40,8 +40,8 @@ describe('Mutation resolveAppealDeleteBan', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow update.state.any', async () => {

--- a/server/test/resolveAppealDeleteMute.mutation.test.js
+++ b/server/test/resolveAppealDeleteMute.mutation.test.js
@@ -40,8 +40,8 @@ describe('Mutation resolveAppealDeleteMute', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow update.state.any', async () => {

--- a/server/test/resolveAppealDeleteWarning.mutation.test.js
+++ b/server/test/resolveAppealDeleteWarning.mutation.test.js
@@ -40,8 +40,8 @@ describe('Mutation resolveAppealDeleteWarning', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow update.state.any', async () => {

--- a/server/test/resolveAppealUpdateBan.mutation.test.js
+++ b/server/test/resolveAppealUpdateBan.mutation.test.js
@@ -42,8 +42,8 @@ describe('Mutation resolveAppealUpdateBan', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow update.state.any', async () => {

--- a/server/test/resolveAppealUpdateMute.mutation.test.js
+++ b/server/test/resolveAppealUpdateMute.mutation.test.js
@@ -42,8 +42,8 @@ describe('Mutation resolveAppealUpdateMute', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow update.state.any', async () => {

--- a/server/test/resolveAppealUpdateWarning.mutation.test.js
+++ b/server/test/resolveAppealUpdateWarning.mutation.test.js
@@ -42,8 +42,8 @@ describe('Mutation resolveAppealUpdateWarning', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should allow update.state.any', async () => {

--- a/server/test/setEmail.mutation.test.js
+++ b/server/test/setEmail.mutation.test.js
@@ -36,8 +36,8 @@ describe('Mutation set email', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should error if current password not correct', async () => {

--- a/server/test/setLocale.mutation.test.js
+++ b/server/test/setLocale.mutation.test.js
@@ -1,0 +1,130 @@
+const assert = require('assert')
+const supertest = require('supertest')
+const createApp = require('../app')
+const { createSetup, getAuthPassword } = require('./lib')
+
+describe('Mutation setLocale', () => {
+  let setup
+  let request
+
+  beforeAll(async () => {
+    setup = await createSetup()
+    const app = await createApp({ ...setup, disableUI: true })
+
+    request = supertest(app.callback())
+  }, 20000)
+
+  afterAll(async () => {
+    await setup.teardown()
+  })
+
+  beforeEach(async () => {
+    await setup.dbPool('bm_web_users').update({ locale: null })
+  })
+
+  test('should error if not logged in', async () => {
+    const { body, statusCode } = await request
+      .post('/graphql')
+      .set('Accept', 'application/json')
+      .send({
+        query: `mutation setLocale {
+        setLocale(locale: "de") {
+          id
+          locale
+        }
+      }`
+      })
+
+    assert.strictEqual(statusCode, 200)
+    assert(body)
+    assert(body.errors)
+    assert.strictEqual(body.errors[0].extensions.code, 'ERR_EXPOSED')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+  })
+
+  test('should error if locale unsupported', async () => {
+    const cookie = await getAuthPassword(request, 'admin@banmanagement.com')
+    const { body, statusCode } = await request
+      .post('/graphql')
+      .set('Cookie', cookie)
+      .set('Accept', 'application/json')
+      .send({
+        query: `mutation setLocale {
+        setLocale(locale: "xx") {
+          id
+          locale
+        }
+      }`
+      })
+
+    assert.strictEqual(statusCode, 200)
+    assert(body)
+    assert(body.errors)
+    assert.strictEqual(body.errors[0].message, 'Locale is not supported')
+    assert.strictEqual(body.errors[0].extensions.code, 'ERR_EXPOSED')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'INVALID_LOCALE')
+  })
+
+  test('should accept supported locale and persist it', async () => {
+    const cookie = await getAuthPassword(request, 'admin@banmanagement.com')
+    const { body, statusCode } = await request
+      .post('/graphql')
+      .set('Cookie', cookie)
+      .set('Accept', 'application/json')
+      .send({
+        query: `mutation setLocale {
+        setLocale(locale: "de") {
+          id
+          locale
+        }
+      }`
+      })
+
+    assert.strictEqual(statusCode, 200)
+    assert(body)
+    assert(body.data)
+    assert.strictEqual(body.data.setLocale.locale, 'de')
+
+    const { body: meBody } = await request
+      .post('/graphql')
+      .set('Cookie', cookie)
+      .set('Accept', 'application/json')
+      .send({
+        query: `query me {
+        me {
+          id
+          locale
+        }
+      }`
+      })
+
+    assert.strictEqual(meBody.data.me.locale, 'de')
+  })
+
+  test('should accept switching back to en after setting de', async () => {
+    const cookie = await getAuthPassword(request, 'admin@banmanagement.com')
+
+    const setDeMutation = 'mutation { setLocale(locale: "de") { id locale } }'
+    const setEnMutation = 'mutation { setLocale(locale: "en") { id locale } }'
+
+    const { body: deBody } = await request
+      .post('/graphql')
+      .set('Cookie', cookie)
+      .set('Accept', 'application/json')
+      .send({ query: setDeMutation })
+
+    assert.strictEqual(deBody.data.setLocale.locale, 'de')
+
+    const { body, statusCode } = await request
+      .post('/graphql')
+      .set('Cookie', cookie)
+      .set('Accept', 'application/json')
+      .send({ query: setEnMutation })
+
+    assert.strictEqual(statusCode, 200)
+    assert(body)
+    assert(body.data)
+    assert.strictEqual(body.data.setLocale.locale, 'en')
+  })
+})

--- a/server/test/setPassword.mutation.test.js
+++ b/server/test/setPassword.mutation.test.js
@@ -52,8 +52,8 @@ describe('Mutation set password', () => {
     assert.strictEqual(statusCode, 200)
 
     assert(body)
-    assert.strictEqual(body.errors[0].message,
-      'You do not have permission to perform this action, please contact your server administrator')
+    assert.strictEqual(body.errors[0].message, 'You are not logged in')
+    assert.strictEqual(body.errors[0].extensions.appCode, 'NOT_LOGGED_IN')
   })
 
   test('should error if current password not provided', async () => {

--- a/utils/format-distance.js
+++ b/utils/format-distance.js
@@ -1,3 +1,7 @@
+import { useEffect, useState } from 'react'
+import { useLocale } from 'next-intl'
+import { DEFAULT_LOCALE, LOCALE_CONFIG } from './locale'
+
 const formatDistanceLocaleTokens = {
   lessThanXSeconds: '{{count}}s',
   xSeconds: '{{count}}s',
@@ -27,4 +31,67 @@ export const formatDistanceLocale = (
   )
 
   return result
+}
+
+// Loaders keyed by the date-fns locale tag (matches LOCALE_CONFIG[*].dateFnsLocale).
+// Adding a new UI locale requires a new entry here AND in LOCALE_CONFIG.
+const dateFnsLocaleLoaders = {
+  'en-GB': () => import('date-fns/locale/en-GB').then((m) => m.enGB),
+  de: () => import('date-fns/locale/de').then((m) => m.de)
+}
+
+// Cache promises (not resolved values) so concurrent first-paint hooks share a single chunk request.
+const localePromiseCache = new Map()
+const localeValueCache = new Map()
+
+const resolveDateFnsTag = (uiLocale) => {
+  const config = LOCALE_CONFIG[uiLocale] || LOCALE_CONFIG[DEFAULT_LOCALE]
+  return config.dateFnsLocale
+}
+
+export const loadDateFnsLocale = (uiLocale) => {
+  const tag = resolveDateFnsTag(uiLocale)
+
+  if (localePromiseCache.has(tag)) return localePromiseCache.get(tag)
+
+  const loader = dateFnsLocaleLoaders[tag] || dateFnsLocaleLoaders[resolveDateFnsTag(DEFAULT_LOCALE)]
+  const promise = loader().then((loaded) => {
+    localeValueCache.set(tag, loaded)
+    return loaded
+  })
+
+  localePromiseCache.set(tag, promise)
+
+  return promise
+}
+
+// Eagerly warm the default locale so first paint has it available without a re-render.
+if (typeof window !== 'undefined') {
+  loadDateFnsLocale(DEFAULT_LOCALE).catch(() => { /* swallow — falls back at use site */ })
+}
+
+export const useDateFnsLocale = () => {
+  const locale = useLocale()
+  const tag = resolveDateFnsTag(locale)
+  const [dateFnsLocale, setDateFnsLocale] = useState(() => localeValueCache.get(tag) || null)
+
+  useEffect(() => {
+    let cancelled = false
+    const cached = localeValueCache.get(tag)
+
+    if (cached) {
+      setDateFnsLocale(cached)
+      return
+    }
+
+    loadDateFnsLocale(locale).then((loaded) => {
+      if (!cancelled) setDateFnsLocale(loaded)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [locale, tag])
+
+  return dateFnsLocale
 }

--- a/utils/index.js
+++ b/utils/index.js
@@ -141,6 +141,7 @@ const userFetcher = () =>
     id
     name
     email
+    locale
     hasAccount
     session {
       type

--- a/utils/locale.js
+++ b/utils/locale.js
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react'
+import { useUser } from './index'
+import {
+  SUPPORTED_LOCALES,
+  DEFAULT_LOCALE,
+  LOCALE_COOKIE,
+  isSupportedLocale,
+  parseCookieHeader,
+  negotiateLocale,
+  negotiateLocaleFromRequest
+} from '../server/data/locales'
+import { translateRestError, translateGraphqlError } from '../server/data/error-translation'
+
+export {
+  SUPPORTED_LOCALES,
+  DEFAULT_LOCALE,
+  LOCALE_COOKIE,
+  isSupportedLocale,
+  negotiateLocale,
+  negotiateLocaleFromRequest,
+  translateRestError,
+  translateGraphqlError
+}
+
+export const LOCALE_CONFIG = {
+  en: {
+    label: 'English',
+    htmlLang: 'en',
+    openGraphLocale: 'en_GB',
+    dateFormat: 'dd/MM/yyyy',
+    dateFnsLocale: 'en-GB'
+  },
+  de: {
+    label: 'Deutsch',
+    htmlLang: 'de',
+    openGraphLocale: 'de_DE',
+    dateFormat: 'dd.MM.yyyy',
+    dateFnsLocale: 'de'
+  }
+}
+
+const readClientCookie = (name) => {
+  if (typeof document === 'undefined') return null
+
+  return parseCookieHeader(document.cookie || '', name)
+}
+
+const negotiateFromNavigator = () => {
+  if (typeof navigator === 'undefined') return null
+
+  const langs = Array.isArray(navigator.languages) ? navigator.languages : [navigator.language]
+
+  for (const lang of langs.filter(Boolean)) {
+    const primary = lang.toLowerCase().split('-')[0]
+
+    if (isSupportedLocale(primary)) return primary
+  }
+
+  return null
+}
+
+export const useResolvedLocale = () => {
+  const { user } = useUser()
+  const [locale, setLocale] = useState(DEFAULT_LOCALE)
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const cookieLocale = readClientCookie(LOCALE_COOKIE)
+
+    if (isSupportedLocale(user?.locale)) {
+      setLocale(user.locale)
+    } else if (isSupportedLocale(cookieLocale)) {
+      setLocale(cookieLocale)
+    } else {
+      const navLocale = negotiateFromNavigator()
+
+      if (navLocale) setLocale(navLocale)
+    }
+
+    setReady(true)
+  }, [user?.locale])
+
+  return { locale, ready }
+}
+
+export const getCookiePath = () => {
+  const basePath = process.env.BASE_PATH || ''
+
+  return basePath || '/'
+}
+
+export const writeLocaleCookie = (locale) => {
+  if (typeof document === 'undefined' || !isSupportedLocale(locale)) return
+
+  const path = getCookiePath()
+  const maxAge = 60 * 60 * 24 * 365
+
+  document.cookie = `${LOCALE_COOKIE}=${encodeURIComponent(locale)}; Path=${path}; Max-Age=${maxAge}; SameSite=Lax`
+}


### PR DESCRIPTION
Introduces full i18n support using next-intl with English (en) and German (de) catalogs, persistent per-user locale preference, locale-aware formatting, and a standardised server-side error code system so messages can be translated client-side.

Highlights:
- next-intl integration with deep-merged English fallback for missing keys
- LanguageSwitcher component + setLocale GraphQL mutation
- bm_web_users.locale column + persisting/loading user preference
- ExposedError now carries stable code + meta; surfaced via GraphQL formatError and Koa error middleware (BAD_USER_INPUT messages pass through verbatim per the documented out-of-scope policy)
- Locale-aware date formatting via dynamic date-fns locale loading with promise dedupe and eager default-locale preload
- Localised react-select and @nateradebaugh/react-datetime widgets
- Comprehensive message extraction across components, pages, notifications
- New server/data/error-translation.js shared by REST + GraphQL helpers
- Added unit tests: error-translation, formatError, locale helpers, setLocale mutation, me.locale field
- Documentation: README + CONTRIBUTING updates covering localisation workflow, adding new locales, and ExposedError compatibility note
