### PR TITLE
feat(i18n): expand coverage and harden locale handling (follow-up to #1765)

### DIFF
--- a/components/AdminLayout.js
+++ b/components/AdminLayout.js
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter, withRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import clsx from 'clsx'
 import { BiServer } from 'react-icons/bi'
 import { MdOutlineGroups, MdOutlineExitToApp, MdOutlineNotifications, MdLogout, MdSettings, MdWebhook, MdOutlineImage } from 'react-icons/md'
@@ -12,14 +13,16 @@ import SessionNavProfile from './SessionNavProfile'
 import { useApi, useUser } from '../utils'
 
 const icons = {
-  Documents: <MdOutlineImage />,
-  Roles: <MdOutlineGroups />,
-  Servers: <BiServer />,
-  'Notification Rules': <MdOutlineNotifications />,
-  Webhooks: <MdWebhook />
+  documents: <MdOutlineImage />,
+  roles: <MdOutlineGroups />,
+  servers: <BiServer />,
+  notificationRules: <MdOutlineNotifications />,
+  webhooks: <MdWebhook />
 }
 
 const AdminLayout = ({ children, title }) => {
+  const t = useTranslations()
+  const tNav = useTranslations('pages.admin.nav')
   const router = useRouter()
   const { user } = useUser({ redirectIfFound: false, redirectTo: '/login' })
   const { loading, data, errors } = useApi({
@@ -27,6 +30,7 @@ const AdminLayout = ({ children, title }) => {
       adminNavigation {
         left {
           id
+          key
           name
           href
           label
@@ -39,10 +43,13 @@ const AdminLayout = ({ children, title }) => {
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const right = [<SessionNavProfile key='session-nav-profile' user={user} />]
-  const left = data.adminNavigation.left
+  const left = data.adminNavigation.left.map(item => ({
+    ...item,
+    name: item.key ? safeTranslate(tNav, item.key, item.name) : item.name
+  }))
   const mobileItems = left.slice()
 
-  mobileItems[mobileItems.length - 1].splitBorder = true
+  if (mobileItems.length) mobileItems[mobileItems.length - 1].splitBorder = true
 
   return (
     <>
@@ -59,7 +66,7 @@ const AdminLayout = ({ children, title }) => {
                   <div className='pt-6 ml-8'>
                     <div className='font-bold text-xl flex w-full'>
                       <span className='mx-4'>
-                        <Link href='/admin'>Admin</Link>
+                        <Link href='/admin'>{t('pages.admin.title')}</Link>
                       </span>
                       <Link href='/dashboard' passHref className='m-auto flex-grow text-right'>
                         <MdOutlineExitToApp className='inline-flex mx-5 hover:text-accent-200' />
@@ -68,7 +75,7 @@ const AdminLayout = ({ children, title }) => {
                   </div>
                   <nav className='mt-6 h-screen flex flex-col justify-between'>
                     <div className='h-full'>
-                      {left.map(({ href, name, label }) => {
+                      {left.map(({ href, name, key, label }) => {
                         const className = clsx('hover:text-accent-200 flex transition-colors text-gray-100 text-xl p-2 my-4', {
                           'border-l-4 border-accent-500': router.asPath === href
                         })
@@ -76,7 +83,7 @@ const AdminLayout = ({ children, title }) => {
                           (
                             <Link key={`${href}${name}`} href={href} passHref className={className}>
 
-                              {icons[name] && <span className='text-left m-auto'>{icons[name]}</span>}
+                              {icons[key] && <span className='text-left m-auto'>{icons[key]}</span>}
                               <span className='mx-4 text-base m-auto font-normal'>
                                 {name}
                               </span>
@@ -102,24 +109,24 @@ const AdminLayout = ({ children, title }) => {
                             <Avatar width='36' height='36' uuid={user.id} />
                             <div className='ml-4 text-sm'>
                               <div>{user.name}</div>
-                              <div>View Profile</div>
+                              <div>{t('pages.admin.layout.viewProfile')}</div>
                             </div>
 
                           </Link>
                         </div>
                       </div>
                       <div className='flex justify-evenly py-3 bg-gray-800'>
-                        <Link href='/notifications' title='Notifications'>
+                        <Link href='/notifications' title={t('pages.admin.layout.notifications')}>
 
                           <MdOutlineNotifications className='w-6 h-6' />
 
                         </Link>
-                        <Link href='/account' title='Settings'>
+                        <Link href='/account' title={t('pages.admin.layout.settings')}>
 
                           <MdSettings className='w-6 h-6' />
 
                         </Link>
-                        <Link href='/dashboard' title='Return'>
+                        <Link href='/dashboard' title={t('pages.admin.layout.return')}>
 
                           <MdLogout className='w-6 h-6' />
 
@@ -141,6 +148,18 @@ const AdminLayout = ({ children, title }) => {
       </div>
     </>
   )
+}
+
+function safeTranslate (translator, key, fallback) {
+  if (typeof translator?.has === 'function' && !translator.has(key)) return fallback
+
+  try {
+    const value = translator(key)
+
+    return value === key ? fallback : value
+  } catch (_) {
+    return fallback
+  }
 }
 
 export default withRouter(AdminLayout)

--- a/components/CommentWithUpload.js
+++ b/components/CommentWithUpload.js
@@ -3,11 +3,13 @@ import { useState, useRef, useCallback, forwardRef, createContext, useContext, u
 import Uploady, { useUploady, useBatchAddListener, useItemProgressListener, useItemFinishListener, useItemErrorListener } from '@rpldy/uploady'
 import { usePasteUpload } from '@rpldy/upload-paste'
 import { FiPaperclip, FiX } from 'react-icons/fi'
+import { useTranslations } from 'next-intl'
 import clsx from 'clsx'
 
 const UploadContext = createContext(null)
 
 function FileChip ({ id, url, name, onRemove, progress, error }) {
+  const t = useTranslations('widgets.upload')
   const isUploading = progress !== undefined && progress < 100
   const displayName = name.length > 20 ? name.slice(0, 17) + '...' : name
 
@@ -37,7 +39,7 @@ function FileChip ({ id, url, name, onRemove, progress, error }) {
           error ? 'text-red-400' : 'text-gray-300'
         )}
       >
-        {error ? 'Failed' : isUploading ? 'Uploading...' : displayName}
+        {error ? t('failed') : isUploading ? t('uploading') : displayName}
       </span>
 
       {/* Delete button with proper touch target */}
@@ -49,7 +51,7 @@ function FileChip ({ id, url, name, onRemove, progress, error }) {
           'text-gray-400 hover:text-white hover:bg-red-500/80'
         )}
         type='button'
-        title='Remove'
+        title={t('remove')}
       >
         <FiX className='w-4 h-4' />
       </button>
@@ -68,6 +70,7 @@ function FileChip ({ id, url, name, onRemove, progress, error }) {
 }
 
 export function AttachButton ({ disabled }) {
+  const t = useTranslations('widgets.upload')
   const ctx = useContext(UploadContext)
   if (!ctx) return null
 
@@ -89,8 +92,8 @@ export function AttachButton ({ disabled }) {
         )}
       >
         <FiPaperclip className='w-4 h-4 flex-shrink-0' />
-        <span className='lg:hidden'>Add files</span>
-        <span className='hidden lg:inline'>Paste, drop, or click to add files</span>
+        <span className='lg:hidden'>{t('addFiles')}</span>
+        <span className='hidden lg:inline'>{t('addFilesLong')}</span>
       </button>
       {maxFiles > 0 && totalFiles > 0 && (
         <span className='text-xs text-gray-500'>
@@ -102,11 +105,12 @@ export function AttachButton ({ disabled }) {
 }
 
 const TextAreaWithUpload = forwardRef(function TextAreaWithUpload (props, ref) {
+  const t = useTranslations('widgets.upload')
   const {
     onDocumentsChange,
     documents = [],
     maxFiles = 3,
-    placeholder = 'Add your comment here...',
+    placeholder,
     maxLength = 250,
     minLength,
     required = false,
@@ -119,6 +123,7 @@ const TextAreaWithUpload = forwardRef(function TextAreaWithUpload (props, ref) {
     children,
     ...rest
   } = props
+  const resolvedPlaceholder = placeholder ?? t('commentPlaceholder')
 
   const containerRef = useRef(null)
   const uploady = useUploady()
@@ -175,7 +180,7 @@ const TextAreaWithUpload = forwardRef(function TextAreaWithUpload (props, ref) {
   })
 
   useItemErrorListener((item) => {
-    let errorMessage = 'Upload failed'
+    let errorMessage = t('uploadFailed')
     try {
       const response = item.uploadResponse?.data
       if (response?.error) {
@@ -283,7 +288,7 @@ const TextAreaWithUpload = forwardRef(function TextAreaWithUpload (props, ref) {
             ref={ref}
             value={value}
             onChange={onChange}
-            placeholder={placeholder}
+            placeholder={resolvedPlaceholder}
             maxLength={maxLength}
             minLength={minLength}
             required={required}
@@ -305,7 +310,7 @@ const TextAreaWithUpload = forwardRef(function TextAreaWithUpload (props, ref) {
                   key={docId}
                   id={docId}
                   url={`${process.env.BASE_PATH || ''}/api/documents/${docId}`}
-                  name={`Image ${idx + 1}`}
+                  name={t('imageName', { index: idx + 1 })}
                   onRemove={handleRemoveUploaded}
                 />
               ))}
@@ -323,7 +328,7 @@ const TextAreaWithUpload = forwardRef(function TextAreaWithUpload (props, ref) {
 
           {isDragging && (
             <div className='absolute inset-0 flex items-center justify-center bg-accent-500/20 rounded-3xl pointer-events-none'>
-              <span className='text-accent-400 font-medium'>Drop images here</span>
+              <span className='text-accent-400 font-medium'>{t('dropImages')}</span>
             </div>
           )}
         </div>

--- a/components/DocumentGallery.js
+++ b/components/DocumentGallery.js
@@ -1,10 +1,12 @@
 /* eslint-disable @next/next/no-img-element */
 import { useState, useEffect } from 'react'
 import { FiTrash2 } from 'react-icons/fi'
+import { useTranslations } from 'next-intl'
 import Modal from './Modal'
 import { useMutateApi } from '../utils'
 
 function DocumentItem ({ document, onDelete, canDelete }) {
+  const t = useTranslations()
   const [confirmDelete, setConfirmDelete] = useState(false)
   const { load, loading, data, errors } = useMutateApi({
     query: `mutation deleteDocument($id: ID!) {
@@ -50,7 +52,7 @@ function DocumentItem ({ document, onDelete, canDelete }) {
             data-cy='document-delete'
             className='absolute top-2 right-2 p-1.5 bg-black/60 hover:bg-red-600 rounded-md text-white opacity-0 group-hover:opacity-100 transition-opacity'
             onClick={() => setConfirmDelete(true)}
-            title='Delete image'
+            title={t('pages.admin.documents.deleteImage')}
           >
             <FiTrash2 className='w-4 h-4' />
           </button>
@@ -58,15 +60,15 @@ function DocumentItem ({ document, onDelete, canDelete }) {
       </div>
 
       <Modal
-        title='Delete Image'
-        confirmButton='Delete'
+        title={t('pages.admin.documents.deleteImageTitle')}
+        confirmButton={t('common.delete')}
         open={confirmDelete}
         onConfirm={handleDelete}
         onCancel={() => setConfirmDelete(false)}
         loading={loading}
       >
-        <p className='pb-1'>Are you sure you want to delete this image?</p>
-        <p className='pb-1 text-gray-400'>This action cannot be undone.</p>
+        <p className='pb-1'>{t('pages.admin.documents.deleteImageConfirm')}</p>
+        <p className='pb-1 text-gray-400'>{t('pages.punishment.actionUndoable')}</p>
         {errors && <p className='text-red-500 text-sm'>{errors[0]?.message}</p>}
       </Modal>
     </>

--- a/components/ErrorLayout.js
+++ b/components/ErrorLayout.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import DefaultLayout from './DefaultLayout'
 import ErrorMessages from './ErrorMessages'
 import PageContainer from './PageContainer'
@@ -5,11 +6,13 @@ import PageHeader from './PageHeader'
 import Panel from './Panel'
 
 export default function ErrorLayout ({ errors }) {
+  const t = useTranslations('errors')
+
   return (
-    <DefaultLayout title='Error'>
+    <DefaultLayout title={t('header')}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader subTitle='Error' title='Something went wrong' />
+          <PageHeader subTitle={t('header')} title={t('somethingWentWrong')} />
           <ErrorMessages errors={errors} />
         </Panel>
       </PageContainer>

--- a/components/LanguageSwitcher.js
+++ b/components/LanguageSwitcher.js
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useRouter } from 'next/router'
 import { useTranslations } from 'next-intl'
 import { mutate } from 'swr'
 import { MdLanguage } from 'react-icons/md'
@@ -10,8 +9,7 @@ import {
   LOCALE_CONFIG,
   SUPPORTED_LOCALES,
   isSupportedLocale,
-  useResolvedLocale,
-  writeLocaleCookie
+  useResolvedLocale
 } from '../utils/locale'
 
 const setLocaleMutation = `
@@ -25,9 +23,8 @@ const setLocaleMutation = `
 
 export default function LanguageSwitcher ({ buttonClassName = '', variant = 'icon' }) {
   const t = useTranslations('widgets.languageSwitcher')
-  const router = useRouter()
   const { user } = useUser()
-  const { locale } = useResolvedLocale()
+  const { locale, setLocale } = useResolvedLocale()
   const [updating, setUpdating] = useState(false)
 
   const persistRemoteLocale = async (next) => {
@@ -56,7 +53,7 @@ export default function LanguageSwitcher ({ buttonClassName = '', variant = 'ico
     if (!isSupportedLocale(next) || next === locale || updating) return
 
     setUpdating(true)
-    writeLocaleCookie(next)
+    setLocale(next)
 
     try {
       if (user?.id) {
@@ -66,7 +63,6 @@ export default function LanguageSwitcher ({ buttonClassName = '', variant = 'ico
     } catch (err) {
       console.error('Failed to persist locale preference', err)
     } finally {
-      router.replace(router.asPath, undefined, { scroll: false })
       setUpdating(false)
     }
   }

--- a/components/NavigationOverlay.js
+++ b/components/NavigationOverlay.js
@@ -1,6 +1,7 @@
 import { createContext } from 'react'
 import { Transition } from '@headlessui/react'
 import { RemoveScroll } from 'react-remove-scroll'
+import { useTranslations } from 'next-intl'
 import clsx from 'clsx'
 
 const NavigationOverlayContext = createContext()
@@ -37,6 +38,8 @@ const NavigationOverlay = ({ children, drawerOpen, setDrawerOpen }) => {
 }
 
 const Header = ({ children }) => {
+  const t = useTranslations('nav')
+
   return (
     <NavigationOverlayContext.Consumer>
       {({ setDrawerOpen }) => (
@@ -47,7 +50,7 @@ const Header = ({ children }) => {
             </div>
             <div className='-mr-2'>
               <button type='button' className='rounded-md p-2 inline-flex items-center justify-center text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none' onClick={() => setDrawerOpen(false)}>
-                <span className='sr-only'>Close menu</span>
+                <span className='sr-only'>{t('closeMenu')}</span>
                 <svg className='h-6 w-6' xmlns='http:www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' aria-hidden='true'>
                   <path strokeLinecap='round' strokeLinejoin='round' strokeWidth='2' d='M6 18L18 6M6 6l12 12' />
                 </svg>

--- a/components/PlayerBanForm.js
+++ b/components/PlayerBanForm.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Input from './Input'
 import Button from './Button'
 import ErrorMessages from './ErrorMessages'
@@ -9,6 +10,7 @@ import { FaPencilAlt } from 'react-icons/fa'
 import ExpiresInput from './ExpiresInput'
 
 export default function PlayerBanForm ({ serverFilter, onFinished, query, parseVariables, disableServers = false, defaults = {}, submitRef = null }) {
+  const t = useTranslations()
   const { handleSubmit, formState, register, control } = useForm({ defaultValues: { ...defaults, server: defaults?.server, expires: defaults?.expires * 1000 || 0 } })
   const { isSubmitting } = formState
   const { load, data, errors } = useMutateApi({ query })
@@ -39,7 +41,7 @@ export default function PlayerBanForm ({ serverFilter, onFinished, query, parseV
       />
       <Input
         required
-        label='Reason'
+        label={t('forms.reason')}
         icon={<FaPencilAlt />}
         data-cy='reason'
         {...register('reason')}
@@ -52,7 +54,7 @@ export default function PlayerBanForm ({ serverFilter, onFinished, query, parseV
         />
       </div>
       <Button data-cy='submit-ban' ref={submitRef} disabled={isSubmitting} loading={isSubmitting} className={submitRef ? 'hidden' : ''}>
-        Save
+        {t('common.save')}
       </Button>
     </form>
   )

--- a/components/PlayerCommentForm.js
+++ b/components/PlayerCommentForm.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useForm, Controller } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Button from './Button'
 import TextArea from './TextArea'
 import ErrorMessages from './ErrorMessages'
@@ -7,6 +8,7 @@ import CommentWithUpload, { AttachButton } from './CommentWithUpload'
 import { useMutateApi } from '../utils'
 
 export default function PlayerCommentForm ({ onFinish, parseVariables, query, canUpload = false }) {
+  const t = useTranslations()
   const { handleSubmit, formState, control, watch, reset } = useForm({ defaultValues: { comment: '' } })
   const { isSubmitting } = formState
   const { load, loading, data, errors } = useMutateApi({ query })
@@ -44,13 +46,12 @@ export default function PlayerCommentForm ({ onFinish, parseVariables, query, ca
                 {...field}
                 required
                 maxLength={250}
-                placeholder='Add your comment here...'
+                placeholder={t('forms.commentPlaceholder')}
                 documents={documentIds}
                 onDocumentsChange={setDocumentIds}
                 maxFiles={3}
                 disabled={loading}
               >
-                {/* Single action row with attach button and comment button */}
                 <div className='flex items-center justify-end gap-4 mt-2 px-2'>
                   <AttachButton disabled={loading} />
                   <Button
@@ -59,7 +60,7 @@ export default function PlayerCommentForm ({ onFinish, parseVariables, query, ca
                     loading={loading}
                     style={{ width: 'auto' }}
                   >
-                    Comment
+                    {t('common.comment')}
                   </Button>
                 </div>
               </CommentWithUpload>
@@ -78,12 +79,12 @@ export default function PlayerCommentForm ({ onFinish, parseVariables, query, ca
                   required
                   className='!-mb-2'
                   maxLength={250}
-                  placeholder='Add your comment here...'
+                  placeholder={t('forms.commentPlaceholder')}
                 />
               )}
             />
             <div className='flex justify-end mt-2'>
-              <Button data-cy='submit-report-comment-form' disabled={isSubmitting || !watchComment.length} loading={loading} style={{ width: 'auto' }}>Comment</Button>
+              <Button data-cy='submit-report-comment-form' disabled={isSubmitting || !watchComment.length} loading={loading} style={{ width: 'auto' }}>{t('common.comment')}</Button>
             </div>
           </>
           )}

--- a/components/PlayerKicks.js
+++ b/components/PlayerKicks.js
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslations } from 'next-intl'
 import Loader from './Loader'
 import ServerSelector from './admin/ServerSelector'
 import { useApi } from '../utils'
@@ -27,6 +28,7 @@ query listPlayerPunishmentRecords($serverId: ID!, $player: UUID!, $type: RecordT
 }`
 
 export default function PlayerKicks ({ id }) {
+  const t = useTranslations()
   const [tableState, setTableState] = useState({ type: 'PlayerKick', serverId: null })
   const { loading, data, mutate } = useApi({ query: !tableState.serverId ? null : query, variables: { ...tableState, player: id } })
 
@@ -44,7 +46,7 @@ export default function PlayerKicks ({ id }) {
         className='pb-4 mb-4 border-b border-primary-900' id='kicks'
       >
         <div className='flex items-center'>
-          <p className='mr-6 text-xl font-bold '>Kicks ({total})</p>
+          <p className='mr-6 text-xl font-bold '>{t('pages.player.kicks', { total })}</p>
           <div className='w-40 inline-block'>
             <ServerSelector
               onChange={serverId => setTableState({ ...tableState, serverId })}
@@ -59,7 +61,7 @@ export default function PlayerKicks ({ id }) {
       {!data?.listPlayerPunishmentRecords?.total && (
         <div className='flex items-center'>
           <div>
-            None
+            {t('common.none')}
           </div>
         </div>
       )}

--- a/components/PlayerMuteForm.js
+++ b/components/PlayerMuteForm.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Input from './Input'
 import Button from './Button'
 import ErrorMessages from './ErrorMessages'
@@ -10,6 +11,7 @@ import ExpiresInput from './ExpiresInput'
 import Switch from './Switch'
 
 export default function PlayerMuteForm ({ serverFilter, onFinished, query, parseVariables, disableServers = false, defaults = {}, submitRef = null }) {
+  const t = useTranslations()
   const { handleSubmit, formState, register, control } = useForm({
     defaultValues: {
       ...defaults,
@@ -47,7 +49,7 @@ export default function PlayerMuteForm ({ serverFilter, onFinished, query, parse
       />
       <Input
         required
-        label='Reason'
+        label={t('forms.reason')}
         icon={<FaPencilAlt />}
         data-cy='reason'
         {...register('reason')}
@@ -64,8 +66,8 @@ export default function PlayerMuteForm ({ serverFilter, onFinished, query, parse
         control={control}
         render={({ field: { onChange, value } }) => (
           <Switch
-            label='Soft'
-            description='Hides their messages to others to prevent spam'
+            label={t('forms.soft')}
+            description={t('forms.softDescription')}
             onChange={onChange}
             checked={value}
             data-cy='mute-soft'
@@ -73,7 +75,7 @@ export default function PlayerMuteForm ({ serverFilter, onFinished, query, parse
         )}
       />
       <Button data-cy='submit-mute' ref={submitRef} disabled={isSubmitting} loading={isSubmitting} className={submitRef ? 'hidden' : ''}>
-        Save
+        {t('common.save')}
       </Button>
     </form>
   )

--- a/components/PlayerNoteForm.js
+++ b/components/PlayerNoteForm.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Button from './Button'
 import ErrorMessages from './ErrorMessages'
 import { useMutateApi } from '../utils'
@@ -8,6 +9,7 @@ import TextArea from './TextArea'
 import InputCharCounter from './InputCharCounter'
 
 export default function PlayerNoteForm ({ serverFilter, onFinished, query, parseVariables, disableServers = false, defaults = {} }) {
+  const t = useTranslations()
   const { handleSubmit, formState, register, control, watch } = useForm({
     defaultValues: {
       message: '',
@@ -46,7 +48,7 @@ export default function PlayerNoteForm ({ serverFilter, onFinished, query, parse
       />
       <TextArea
         required
-        label='Message'
+        label={t('forms.message')}
         minLength={1}
         maxLength={255}
         className='!-mb-6'
@@ -55,7 +57,7 @@ export default function PlayerNoteForm ({ serverFilter, onFinished, query, parse
       />
       <InputCharCounter currentLength={watchMessage?.length} maxLength={255} />
       <Button data-cy='submit-note' disabled={isSubmitting || !watchMessage?.length} loading={isSubmitting} className='mt-6'>
-        Save
+        {t('common.save')}
       </Button>
     </form>
   )

--- a/components/PlayerWarnForm.js
+++ b/components/PlayerWarnForm.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Input from './Input'
 import Button from './Button'
 import ErrorMessages from './ErrorMessages'
@@ -10,6 +11,7 @@ import { RiNumbersLine } from 'react-icons/ri'
 import ExpiresInput from './ExpiresInput'
 
 export default function PlayerWarnForm ({ serverFilter, onFinished, query, parseVariables, disableServers = false, defaults = {}, submitRef = null }) {
+  const t = useTranslations()
   const { handleSubmit, formState, register, control } = useForm({ defaultValues: { ...defaults, server: defaults?.server, expires: defaults?.expires * 1000 || 0, points: defaults?.points || 1 } })
   const { isSubmitting } = formState
   const { load, data, errors } = useMutateApi({ query })
@@ -40,14 +42,14 @@ export default function PlayerWarnForm ({ serverFilter, onFinished, query, parse
       />
       <Input
         required
-        label='Reason'
+        label={t('forms.reason')}
         icon={<FaPencilAlt />}
         data-cy='reason'
         {...register('reason')}
       />
       <Input
         required
-        label='Points'
+        label={t('forms.points')}
         type='number'
         min='0'
         step='.01'
@@ -63,7 +65,7 @@ export default function PlayerWarnForm ({ serverFilter, onFinished, query, parse
         />
       </div>
       <Button data-cy='submit-warning' ref={submitRef} disabled={isSubmitting} loading={isSubmitting} className={submitRef ? 'hidden' : ''}>
-        Save
+        {t('common.save')}
       </Button>
     </form>
   )

--- a/components/ResetEmailForm.js
+++ b/components/ResetEmailForm.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import { MdLock, MdOutlineEmail } from 'react-icons/md'
 import Input from './Input'
 import Button from './Button'
@@ -7,6 +8,7 @@ import { useMutateApi } from '../utils'
 import { useRouter } from 'next/router'
 
 export default function ResetEmailForm () {
+  const t = useTranslations()
   const router = useRouter()
   const { handleSubmit, formState, register } = useForm()
   const { isSubmitting } = formState
@@ -31,7 +33,7 @@ export default function ResetEmailForm () {
       <div className='flex flex-col relative w-full'>
         <Input
           required
-          label='New email address'
+          label={t('pages.account.newEmail')}
           type='email'
           icon={<MdOutlineEmail />}
           iconPosition='left'
@@ -40,7 +42,7 @@ export default function ResetEmailForm () {
         />
         <Input
           required
-          label='Current password'
+          label={t('forms.currentPassword')}
           type='password'
           icon={<MdLock />}
           iconPosition='left'
@@ -49,7 +51,7 @@ export default function ResetEmailForm () {
           {...register('currentPassword')}
         />
         <Button data-cy='submit-email-change' disabled={isSubmitting} loading={isSubmitting}>
-          Save
+          {t('common.save')}
         </Button>
       </div>
     </form>

--- a/components/ResetPasswordForm.js
+++ b/components/ResetPasswordForm.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import { MdLock } from 'react-icons/md'
 import Input from './Input'
 import Button from './Button'
@@ -7,6 +8,7 @@ import { useMutateApi, useUser } from '../utils'
 import { useRouter } from 'next/router'
 
 export default function ResetPasswordForm () {
+  const t = useTranslations()
   const router = useRouter()
   const { user } = useUser()
   const [error, setError] = useState(null)
@@ -31,7 +33,7 @@ export default function ResetPasswordForm () {
 
   const onSubmit = async (data) => {
     if (data.confirmPassword !== data.newPassword) {
-      setError(new Error('Passwords do not match'))
+      setError(new Error(t('forms.passwordMismatch')))
     } else {
       setError(null)
       return load(data)
@@ -44,7 +46,7 @@ export default function ResetPasswordForm () {
         {user?.session?.type === 'password' &&
           <Input
             required
-            label='Current password'
+            label={t('forms.currentPassword')}
             minLength={6}
             type='password'
             icon={<MdLock />}
@@ -54,18 +56,18 @@ export default function ResetPasswordForm () {
           />}
         <Input
           required
-          label='New password'
+          label={t('pages.account.newPassword')}
           minLength={6}
           type='password'
           icon={<MdLock />}
           iconPosition='left'
           data-cy='newPassword'
-          description='Must be at least 6 characters long'
+          description={t('pages.account.passwordHint')}
           {...register('newPassword')}
         />
         <Input
           required
-          label='Confirm new password'
+          label={t('pages.account.confirmNewPassword')}
           type='password'
           minLength={6}
           icon={<MdLock />}
@@ -75,7 +77,7 @@ export default function ResetPasswordForm () {
           {...register('confirmPassword')}
         />
         <Button data-cy='submit-password-change' disabled={isSubmitting} loading={isSubmitting}>
-          Save
+          {t('common.save')}
         </Button>
       </div>
     </form>

--- a/components/admin/AssignPlayersRoleForm.js
+++ b/components/admin/AssignPlayersRoleForm.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { useForm, Controller } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Button from '../Button'
 import Select from '../Select'
 import PlayerSelector from './PlayerSelector'
@@ -8,6 +9,7 @@ import ErrorMessages from '../ErrorMessages'
 import { useMutateApi } from '../../utils'
 
 export default function AssignPlayersRoleForm ({ query, roles, servers = [] }) {
+  const t = useTranslations()
   const playersRef = useRef()
   const { handleSubmit, formState, control, setValue } = useForm({
     defaultValues: {
@@ -45,7 +47,7 @@ export default function AssignPlayersRoleForm ({ query, roles, servers = [] }) {
           name='role'
           control={control}
           rules={{ required: true }}
-          render={({ field }) => <Select className='mb-6' placeholder='Role' options={rolesDropdown} {...field} />}
+          render={({ field }) => <Select className='mb-6' placeholder={t('pages.admin.roles.role')} options={rolesDropdown} {...field} />}
         />
         {!!servers.length &&
           <Controller
@@ -53,10 +55,10 @@ export default function AssignPlayersRoleForm ({ query, roles, servers = [] }) {
             control={control}
             defaultValue={false}
             rules={{ required: true }}
-            render={({ field }) => <ServerSelector className='mb-6' placeholder='Server' {...field} />}
+            render={({ field }) => <ServerSelector className='mb-6' placeholder={t('pages.admin.servers.server')} {...field} />}
           />}
         <Button data-cy='submit-players-role' disabled={isSubmitting} loading={loading} className='w-24 mb-5'>
-          Assign
+          {t('pages.admin.roles.assign')}
         </Button>
       </div>
     </form>

--- a/components/admin/DocumentsTable.js
+++ b/components/admin/DocumentsTable.js
@@ -1,6 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import { FiTrash2, FiExternalLink, FiZoomIn, FiX } from 'react-icons/fi'
 import Modal from '../Modal'
 import { formatBytes, fromNow, useMutateApi } from '../../utils'
@@ -33,6 +34,7 @@ function ImageModal ({ document, onClose }) {
 }
 
 function DocumentRow ({ document, onDelete }) {
+  const t = useTranslations()
   const [showZoom, setShowZoom] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
   const { load, loading, data, errors } = useMutateApi({
@@ -90,7 +92,7 @@ function DocumentRow ({ document, onDelete }) {
               </Link>
               )
             : (
-              <span className='text-gray-500'>Unknown</span>
+              <span className='text-gray-500'>{t('pages.admin.documents.unknown')}</span>
               )}
         </td>
         <td className='px-4 py-3'>
@@ -120,7 +122,7 @@ function DocumentRow ({ document, onDelete }) {
               </div>
               )
             : (
-              <span className='text-gray-500 text-sm'>Not attached</span>
+              <span className='text-gray-500 text-sm'>{t('pages.admin.documents.notAttached')}</span>
               )}
         </td>
         <td className='px-4 py-3 text-gray-400'>
@@ -131,7 +133,7 @@ function DocumentRow ({ document, onDelete }) {
             <button
               className='p-2 text-gray-400 hover:text-white hover:bg-primary-600 rounded transition-colors'
               onClick={() => setShowZoom(true)}
-              title='View full size'
+              title={t('pages.admin.documents.viewFullSize')}
               data-cy='admin-document-preview'
             >
               <FiZoomIn className='w-4 h-4' />
@@ -141,7 +143,7 @@ function DocumentRow ({ document, onDelete }) {
               target='_blank'
               rel='noopener noreferrer'
               className='p-2 text-gray-400 hover:text-white hover:bg-primary-600 rounded transition-colors'
-              title='Open in new tab'
+              title={t('pages.admin.documents.openInNewTab')}
               data-cy='admin-document-open'
             >
               <FiExternalLink className='w-4 h-4' />
@@ -150,7 +152,7 @@ function DocumentRow ({ document, onDelete }) {
               <button
                 className='p-2 text-gray-400 hover:text-red-400 hover:bg-primary-600 rounded transition-colors'
                 onClick={() => setConfirmDelete(true)}
-                title='Delete'
+                title={t('common.delete')}
                 data-cy='admin-document-delete'
               >
                 <FiTrash2 className='w-4 h-4' />
@@ -165,15 +167,15 @@ function DocumentRow ({ document, onDelete }) {
       )}
 
       <Modal
-        title='Delete Document'
-        confirmButton='Delete'
+        title={t('pages.admin.documents.deleteTitle')}
+        confirmButton={t('common.delete')}
         open={confirmDelete}
         onConfirm={handleDelete}
         onCancel={() => setConfirmDelete(false)}
         loading={loading}
       >
-        <p className='pb-1'>Are you sure you want to delete this document?</p>
-        <p className='pb-1 text-gray-400'>This action cannot be undone and will remove the image from any appeals it was attached to.</p>
+        <p className='pb-1'>{t('pages.admin.documents.deleteConfirm')}</p>
+        <p className='pb-1 text-gray-400'>{t('pages.admin.documents.deleteWarning')}</p>
         {errors && errors.length > 0 && <p className='text-red-500 text-sm'>{errors[0]?.message}</p>}
       </Modal>
     </>
@@ -181,16 +183,18 @@ function DocumentRow ({ document, onDelete }) {
 }
 
 export default function DocumentsTable ({ documents, onDelete }) {
+  const t = useTranslations('pages.admin.documents')
+
   return (
     <div className='overflow-x-auto bg-primary-800 rounded-lg' data-cy='admin-documents-table'>
       <table className='w-full'>
         <thead>
           <tr className='text-left text-gray-400 text-sm border-b border-primary-600'>
-            <th className='px-4 py-3 font-medium'>Document</th>
-            <th className='px-4 py-3 font-medium'>Uploaded By</th>
-            <th className='px-4 py-3 font-medium'>Used In</th>
-            <th className='px-4 py-3 font-medium'>Date</th>
-            <th className='px-4 py-3 font-medium'>Actions</th>
+            <th className='px-4 py-3 font-medium'>{t('document')}</th>
+            <th className='px-4 py-3 font-medium'>{t('uploadedBy')}</th>
+            <th className='px-4 py-3 font-medium'>{t('usedIn')}</th>
+            <th className='px-4 py-3 font-medium'>{t('date')}</th>
+            <th className='px-4 py-3 font-medium'>{t('actions')}</th>
           </tr>
         </thead>
         <tbody>

--- a/components/admin/PlayerEditForm.js
+++ b/components/admin/PlayerEditForm.js
@@ -1,5 +1,6 @@
 import { Fragment, useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Avatar from '../Avatar'
 import Input from '../Input'
 import Modal from '../Modal'
@@ -9,6 +10,8 @@ import { useMutateApi } from '../../utils'
 import PageHeader from '../PageHeader'
 
 export default function PlayerEditForm ({ open, onFinished, onCancel, player, roles, servers }) {
+  const t = useTranslations()
+
   if (!player) return null
 
   const { handleSubmit, register, control } = useForm({
@@ -77,7 +80,7 @@ export default function PlayerEditForm ({ open, onFinished, onCancel, player, ro
       open={open}
       onCancel={onCancel}
       onConfirm={handleSubmit(onSubmit)}
-      confirmButton='Save'
+      confirmButton={t('common.save')}
       title={
         <div className='flex items-center'>
           <span className='flex-shrink-0'>
@@ -91,11 +94,11 @@ export default function PlayerEditForm ({ open, onFinished, onCancel, player, ro
         <ErrorMessages errors={errors} />
         {player.email &&
           <Input
-            placeholder='Email'
+            placeholder={t('tables.email')}
             readOnly
             {...register('email')}
           />}
-        <PageHeader title='Global Roles' className='!text-xl' />
+        <PageHeader title={t('pages.admin.players.globalRoles')} className='!text-xl' />
         <Controller
           name='roles'
           control={control}
@@ -103,7 +106,7 @@ export default function PlayerEditForm ({ open, onFinished, onCancel, player, ro
           render={({ field }) => <Select
             className='mb-6'
             options={rolesDropdown}
-            placeholder='Role'
+            placeholder={t('pages.admin.roles.role')}
             isMulti
             {...field}
             onChange={(selectedOption) => {
@@ -121,7 +124,7 @@ export default function PlayerEditForm ({ open, onFinished, onCancel, player, ro
                 render={({ field }) => <Select
                   className='mb-6'
                   options={rolesDropdown}
-                  placeholder='Role'
+                  placeholder={t('pages.admin.roles.role')}
                   isMulti
                   {...field}
                   onChange={(selectedOption) => {

--- a/components/admin/PlayersTable.js
+++ b/components/admin/PlayersTable.js
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslations } from 'next-intl'
 import Input from '../Input'
 import Table from '../Table'
 import Pagination from '../Pagination'
@@ -37,6 +38,7 @@ query listUsers($email: String, $role: String, $serverRole: String, $limit: Int,
 }`
 
 export default function PlayersTable ({ limit = 30, roles, servers }) {
+  const t = useTranslations()
   const [tableState, setTableState] = useState({ activePage: 1, limit, offset: 0, email: '', role: '', serverRole: '' })
   const [editState, setEditState] = useState({ playerEditOpen: false, currentPlayer: null })
   const { loading, data, mutate } = useApi({ query, variables: tableState })
@@ -77,10 +79,10 @@ export default function PlayersTable ({ limit = 30, roles, servers }) {
       <Table>
         <Table.Header>
           <Table.Row>
-            <Table.HeaderCell>Name</Table.HeaderCell>
-            <Table.HeaderCell><Input className='mb-0' inputClassName='!text-sm' name='email' placeholder='Email' value={tableState.email} onChange={handleFilter} /></Table.HeaderCell>
-            <Table.HeaderCell><Input className='mb-0' inputClassName='!text-sm' name='role' placeholder='Global Roles' value={tableState.role} onChange={handleFilter} /></Table.HeaderCell>
-            <Table.HeaderCell><Input className='mb-0' inputClassName='!text-sm' name='serverRole' placeholder='Server Roles' value={tableState.serverRole} onChange={handleFilter} /></Table.HeaderCell>
+            <Table.HeaderCell>{t('tables.name')}</Table.HeaderCell>
+            <Table.HeaderCell><Input className='mb-0' inputClassName='!text-sm' name='email' placeholder={t('tables.email')} value={tableState.email} onChange={handleFilter} /></Table.HeaderCell>
+            <Table.HeaderCell><Input className='mb-0' inputClassName='!text-sm' name='role' placeholder={t('pages.admin.players.globalRoles')} value={tableState.role} onChange={handleFilter} /></Table.HeaderCell>
+            <Table.HeaderCell><Input className='mb-0' inputClassName='!text-sm' name='serverRole' placeholder={t('pages.admin.players.serverRoles')} value={tableState.serverRole} onChange={handleFilter} /></Table.HeaderCell>
             <Table.HeaderCell />
           </Table.Row>
         </Table.Header>
@@ -108,7 +110,7 @@ export default function PlayersTable ({ limit = 30, roles, servers }) {
                 <Table.Cell><p className='px-4'>{row.serverRoles.map(({ serverRole }) => serverRole.name).join(', ')}</p></Table.Cell>
                 <Table.Cell>
                   <a href='#' className='text-accent-600 hover:text-accent-100' onClick={handleOpen(row)}>
-                    Edit
+                    {t('common.edit')}
                   </a>
                 </Table.Cell>
               </Table.Row>

--- a/components/admin/RoleForm.js
+++ b/components/admin/RoleForm.js
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useRef } from 'react'
 import { cloneDeep, find } from 'lodash-es'
 import { useForm, Controller } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Input from '../Input'
 import Checkbox from '../Checkbox'
 import Button from '../Button'
@@ -13,6 +14,7 @@ const sanitiseName = (name) => name.replace(/\./g, '_')
 const desanitiseName = (name) => name.replace(/_/g, '.')
 
 export default function RoleForm ({ onFinished, query, parseVariables, parentRoles, resources, defaults = {} }) {
+  const t = useTranslations()
   const defaultResources = {}
 
   ;(defaults.resources || resources || []).forEach(resource => {
@@ -77,11 +79,11 @@ export default function RoleForm ({ onFinished, query, parseVariables, parentRol
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className='mx-auto' data-cy='role-form'>
-      <PageHeader title='Edit Role' />
+      <PageHeader title={t('pages.admin.roles.form.edit')} />
       <ErrorMessages ref={errorRef} errors={errors} />
       <Input
         required
-        placeholder='Name'
+        placeholder={t('pages.admin.roles.form.name')}
         data-cy='role-name'
         {...register('name')}
       />
@@ -91,11 +93,11 @@ export default function RoleForm ({ onFinished, query, parseVariables, parentRol
           control={control}
           render={({ field }) => <Select className='mb-6' {...field} options={parentRoles} data-cy='role-parent' />}
         />}
-      <PageHeader title='Resources' className='!text-xl' />
+      <PageHeader title={t('pages.admin.roles.form.resources')} className='!text-xl' />
       {defaults.id === '3' &&
-        <p>{defaults.name} has access to all resources</p>}
+        <p>{t('pages.admin.roles.form.fullAccess', { name: defaults.name })}</p>}
       {(!defaults.id || defaults.id !== '3') && resourceInputs}
-      <Button data-cy='submit-role-form' disabled={isSubmitting} loading={loading}>Save</Button>
+      <Button data-cy='submit-role-form' disabled={isSubmitting} loading={loading}>{t('common.save')}</Button>
     </form>
   )
 }

--- a/components/admin/RoleItem.js
+++ b/components/admin/RoleItem.js
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import Modal from '../Modal'
 import { useMutateApi } from '../../utils'
 import ErrorMessages from '../ErrorMessages'
 
 export default function RoleItem ({ role, onDeleted }) {
+  const t = useTranslations()
   const [open, setOpen] = useState(false)
   const { load, loading, errors, data } = useMutateApi({
     query: `mutation deleteRole($id: ID!) {
@@ -34,16 +36,16 @@ export default function RoleItem ({ role, onDeleted }) {
   return (
     <div className='bg-black shadow-md rounded-md overflow-hidden text-center w-80' data-cy='role-item' data-cy-role={role.name}>
       <Modal
-        title='Delete role'
-        confirmButton='Delete'
+        title={t('pages.admin.roles.deleteTitle')}
+        confirmButton={t('common.delete')}
         open={open}
         onConfirm={handleConfirmDelete}
         onCancel={handleDeleteCancel}
         loading={loading}
       >
         <ErrorMessages errors={errors} />
-        <p className='pb-1'>Are you sure you want to delete this role?</p>
-        <p className='pb-1'>This action cannot be undone</p>
+        <p className='pb-1'>{t('pages.admin.roles.deleteConfirm')}</p>
+        <p className='pb-1'>{t('pages.punishment.actionUndoable')}</p>
       </Modal>
       <Link href={`/admin/roles/${role.id}`} passHref>
 
@@ -77,20 +79,20 @@ export default function RoleItem ({ role, onDeleted }) {
               onClick={showConfirmDelete}
               data-cy='role-delete'
             >
-              Delete
+              {t('common.delete')}
             </button>
           </div>}
         {role.id === '1' &&
           <div className='py-3 px-5 bg-gray-900'>
-            Assigned by default to all non-logged in visitors
+            {t('pages.admin.roles.defaultUnauthenticated')}
           </div>}
         {role.id === '2' &&
           <div className='py-3 px-5 bg-gray-900'>
-            Assigned by default for all logged in players
+            {t('pages.admin.roles.defaultAuthenticated')}
           </div>}
         {role.id === '3' &&
           <div className='py-3 px-5 bg-gray-900'>
-            Super admin role with all permissions
+            {t('pages.admin.roles.superAdmin')}
           </div>}
 
       </Link>

--- a/components/admin/ServerForm.js
+++ b/components/admin/ServerForm.js
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { load as safeLoad } from 'js-yaml'
 import { useForm } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Input from '../Input'
 import TextArea from '../TextArea'
 import Button from '../Button'
@@ -9,6 +10,7 @@ import PageHeader from '../PageHeader'
 import { useMutateApi } from '../../utils'
 
 export default function ServerForm ({ onFinished, query, parseVariables, serverTables, defaults = {} }) {
+  const t = useTranslations()
   const errorRef = useRef(null)
   const [yamlState, setYamlState] = useState('')
   const { handleSubmit, formState, register, setValue } = useForm({ defaultValues: { ...defaults, console: defaults?.console?.id } })
@@ -66,22 +68,22 @@ export default function ServerForm ({ onFinished, query, parseVariables, serverT
       <ErrorMessages ref={errorRef} errors={errors} />
       <div className='grid grid-flow-row md:grid-flow-col gap-6'>
         <div className='grid-flow-col'>
-          <PageHeader title='Info' />
+          <PageHeader title={t('pages.admin.servers.form.info')} />
           <Input
             required
-            placeholder='Name'
+            placeholder={t('pages.admin.servers.form.name')}
             data-cy='server-name'
             {...register('name')}
           />
           <Input
             required
-            placeholder='Console UUID (BanManager/console.yml)'
+            placeholder={t('pages.admin.servers.form.consoleUuid')}
             minLength={16}
             data-cy='server-console'
             {...register('console')}
           />
           <TextArea
-            placeholder='Paste YAML BanManager/config.yml (Optional)'
+            placeholder={t('pages.admin.servers.form.yamlPlaceholder')}
             value={yamlState}
             name='yaml'
             onChange={handleYamlConfig}
@@ -89,42 +91,42 @@ export default function ServerForm ({ onFinished, query, parseVariables, serverT
           />
         </div>
         <div className='grid-flow-col'>
-          <PageHeader title='Database' />
+          <PageHeader title={t('pages.admin.servers.form.database')} />
           <Input
             required
-            placeholder='Host'
+            placeholder={t('pages.admin.servers.form.host')}
             data-cy='server-host'
             {...register('host')}
           />
           <Input
             required
-            placeholder='Port'
+            placeholder={t('pages.admin.servers.form.port')}
             data-cy='server-port'
             {...register('port', { valueAsNumber: true })}
           />
           <Input
             required
-            placeholder='Database Name'
+            placeholder={t('pages.admin.servers.form.databaseName')}
             data-cy='server-database'
             {...register('database')}
           />
           <Input
             required
-            placeholder='User'
+            placeholder={t('pages.admin.servers.form.user')}
             data-cy='server-user'
             {...register('user')}
           />
           <Input
-            placeholder='Password'
+            placeholder={t('pages.admin.servers.form.password')}
             type='password'
             data-cy='server-password'
             {...register('password')}
           />
         </div>
       </div>
-      <PageHeader title='Database Tables' />
+      <PageHeader title={t('pages.admin.servers.form.databaseTables')} />
       {tableInputs}
-      <Button data-cy='submit-server-form' disabled={isSubmitting} loading={loading}>Save</Button>
+      <Button data-cy='submit-server-form' disabled={isSubmitting} loading={loading}>{t('common.save')}</Button>
     </form>
   )
 }

--- a/components/admin/ServerItem.js
+++ b/components/admin/ServerItem.js
@@ -3,6 +3,7 @@ import { FaBan } from 'react-icons/fa'
 import { BsMicMute } from 'react-icons/bs'
 import { AiOutlineWarning } from 'react-icons/ai'
 import { GoReport } from 'react-icons/go'
+import { useTranslations } from 'next-intl'
 import clsx from 'clsx'
 import Link from 'next/link'
 import ResponsivePie, { PieContext } from '../charts/ResponsivePie'
@@ -26,6 +27,7 @@ const StatItem = ({ onClick, icon, value, selected }) => {
 }
 
 export default function ServerItem ({ canDelete, server, onDeleted }) {
+  const t = useTranslations()
   const [open, setOpen] = useState(false)
   const [confirmValue, setConfirmValue] = useState('')
   const { load, loading, errors, data } = useMutateApi({
@@ -86,8 +88,8 @@ export default function ServerItem ({ canDelete, server, onDeleted }) {
   return (
     <div className='bg-black shadow-md rounded-md overflow-hidden text-center w-80' data-cy='server-item' data-cy-server={server.name}>
       <Modal
-        title='Delete server'
-        confirmButton='Delete'
+        title={t('pages.admin.servers.deleteTitle')}
+        confirmButton={t('common.delete')}
         confirmDisabled={confirmValue !== server.name}
         open={open}
         onConfirm={handleConfirmDelete}
@@ -96,16 +98,16 @@ export default function ServerItem ({ canDelete, server, onDeleted }) {
       >
         <ErrorMessages errors={errors} />
         <Message warning>
-          <Message.Header>Warning</Message.Header>
+          <Message.Header>{t('common.warning')}</Message.Header>
           <Message.List>
-            <Message.Item>Related <strong>appeals and roles</strong> will be removed</Message.Item>
-            <Message.Item>This action cannot be undone</Message.Item>
+            <Message.Item><span dangerouslySetInnerHTML={{ __html: t.raw('pages.admin.servers.deleteWarning') }} /></Message.Item>
+            <Message.Item>{t('pages.punishment.actionUndoable')}</Message.Item>
           </Message.List>
         </Message>
-        <p className='mb-4'>Please type <strong>{server.name}</strong> to confirm</p>
+        <p className='mb-4'><span dangerouslySetInnerHTML={{ __html: t.raw('pages.admin.servers.deleteConfirmInstruction').replace('{name}', server.name) }} /></p>
         <Input
           onChange={(e, { value }) => setConfirmValue(value)}
-          placeholder='Type server name'
+          placeholder={t('pages.admin.servers.deletePlaceholder')}
           className='mb-0'
           inputClassName='border border-gray-900'
           required
@@ -145,7 +147,7 @@ export default function ServerItem ({ canDelete, server, onDeleted }) {
               onClick={showConfirmDelete}
               data-cy='server-delete'
             >
-              Delete
+              {t('common.delete')}
             </button>}
         </div>
       </div>

--- a/components/admin/notification-rules/NotificationRuleForm.js
+++ b/components/admin/notification-rules/NotificationRuleForm.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { useForm, Controller } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Button from '../../Button'
 import PageHeader from '../AdminHeader'
 import ErrorMessages from '../../ErrorMessages'
@@ -8,6 +9,7 @@ import ServerSelector from '../ServerSelector'
 import { useMutateApi } from '../../../utils'
 
 export default function NotificationRuleForm ({ onFinished, query, parseVariables, notificationTypes, roles, defaults = {} }) {
+  const t = useTranslations()
   const errorRef = useRef(null)
   const { handleSubmit, formState, control } = useForm({
     defaultValues: {
@@ -37,7 +39,7 @@ export default function NotificationRuleForm ({ onFinished, query, parseVariable
   return (
     <form onSubmit={handleSubmit(onSubmit)} className='mx-auto w-full' data-cy='notification-rule-form'>
       <ErrorMessages ref={errorRef} errors={errors} />
-      <PageHeader title='Notification Type' className='!text-xl' />
+      <PageHeader title={t('pages.admin.notificationRules.form.type')} className='!text-xl' />
       <div data-cy='notification-rule-type'>
         <Controller
           name='type'
@@ -53,7 +55,7 @@ export default function NotificationRuleForm ({ onFinished, query, parseVariable
                                  />}
         />
       </div>
-      <PageHeader title='Roles' className='!text-xl' />
+      <PageHeader title={t('pages.admin.notificationRules.form.roles')} className='!text-xl' />
       <div data-cy='notification-rule-roles'>
         <Controller
           name='roles'
@@ -70,16 +72,16 @@ export default function NotificationRuleForm ({ onFinished, query, parseVariable
                                  />}
         />
       </div>
-      <PageHeader title='Server (optional)' className='!text-xl' />
+      <PageHeader title={t('pages.admin.notificationRules.form.serverOptional')} className='!text-xl' />
       <div data-cy='notification-rule-server'>
         <Controller
           name='serverId'
           control={control}
           defaultValue={false}
-          render={({ field }) => <ServerSelector isClearable className='mb-6' placeholder='Server' {...field} />}
+          render={({ field }) => <ServerSelector isClearable className='mb-6' placeholder={t('pages.admin.notificationRules.form.server')} {...field} />}
         />
       </div>
-      <Button data-cy='submit-notification-rule-form' disabled={isSubmitting} loading={loading}>Save</Button>
+      <Button data-cy='submit-notification-rule-form' disabled={isSubmitting} loading={loading}>{t('common.save')}</Button>
     </form>
   )
 }

--- a/components/admin/notification-rules/NotificationRuleItem.js
+++ b/components/admin/notification-rules/NotificationRuleItem.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import { BiServer } from 'react-icons/bi'
 import { MdOutlineGroups } from 'react-icons/md'
 import { FaPencilAlt } from 'react-icons/fa'
@@ -11,6 +12,7 @@ import { useMutateApi } from '../../../utils'
 import ErrorMessages from '../../ErrorMessages'
 
 export default function NotificationRuleItem ({ row, onDeleted }) {
+  const t = useTranslations()
   const [open, setOpen] = useState(false)
   const { load, loading, errors, data } = useMutateApi({
     query: `mutation deleteNotificationRule($id: ID!) {
@@ -40,16 +42,16 @@ export default function NotificationRuleItem ({ row, onDeleted }) {
   return (
     <div className='hover:bg-gray-900 group border-b border-gray-700' data-cy='notification-rule-item' data-cy-rule-id={row.id}>
       <Modal
-        title='Delete notification rule'
-        confirmButton='Delete'
+        title={t('pages.admin.notificationRules.deleteTitle')}
+        confirmButton={t('common.delete')}
         open={open}
         onConfirm={handleConfirmDelete}
         onCancel={handleDeleteCancel}
         loading={loading}
       >
         <ErrorMessages errors={errors} />
-        <p className='pb-1'>Are you sure you want to delete this notification rule?</p>
-        <p className='pb-1'>This action cannot be undone</p>
+        <p className='pb-1'>{t('pages.admin.notificationRules.deleteConfirm')}</p>
+        <p className='pb-1'>{t('pages.punishment.actionUndoable')}</p>
       </Modal>
       <div className='flex py-2'>
         <div className='flex-auto flex-wrap space-y-2 pl-3 py-2'>
@@ -89,12 +91,12 @@ export default function NotificationRuleItem ({ row, onDeleted }) {
         <div>
           <Link href={`/admin/notification-rules/${row.id}`} passHref>
 
-            <Button data-cy='notification-rule-edit-mobile' className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><FaPencilAlt /> Edit</Button>
+            <Button data-cy='notification-rule-edit-mobile' className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><FaPencilAlt /> {t('common.edit')}</Button>
 
           </Link>
         </div>
         <div>
-          <Button data-cy='notification-rule-delete-mobile' className='bg-red-600 hover:bg-red-700 text-sm px-4 py-2' onClick={showConfirmDelete}><BsTrash /> Delete</Button>
+          <Button data-cy='notification-rule-delete-mobile' className='bg-red-600 hover:bg-red-700 text-sm px-4 py-2' onClick={showConfirmDelete}><BsTrash /> {t('common.delete')}</Button>
         </div>
       </div>
     </div>

--- a/components/admin/servers/PlayerActivity.js
+++ b/components/admin/servers/PlayerActivity.js
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { fromUnixTime, getUnixTime } from 'date-fns'
 import { capitalize } from 'lodash-es'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import { AiOutlinePlus, AiOutlineMinus } from 'react-icons/ai'
 import { BiTime } from 'react-icons/bi'
 import { MdClear, MdFilterAlt } from 'react-icons/md'
@@ -56,44 +57,45 @@ const types = [
 ]
 
 const ActivityRow = ({ row, index }) => {
+  const t = useTranslations()
   const message = []
 
   switch (row.type) {
     case 'BAN':
-      message.push('Banned')
+      message.push(t('pages.admin.servers.playerActivity.actions.BAN'))
       break
     case 'IPBAN':
-      message.push(`Banned ${row.fromIp}`)
+      message.push(t('pages.admin.servers.playerActivity.actions.IPBAN', { ip: row.fromIp }))
       break
     case 'UNBAN':
-      message.push('Unbanned')
+      message.push(t('pages.admin.servers.playerActivity.actions.UNBAN'))
       break
     case 'UNBANIP':
-      message.push(`Unbanned ${row.fromIp}`)
+      message.push(t('pages.admin.servers.playerActivity.actions.UNBANIP', { ip: row.fromIp }))
       break
     case 'IPRANGEBAN':
-      message.push(`Banned ${row.fromIp} - ${row.toIp}`)
+      message.push(t('pages.admin.servers.playerActivity.actions.IPRANGEBAN', { fromIp: row.fromIp, toIp: row.toIp }))
       break
     case 'IPRANGEUNBAN':
-      message.push(`Unbanned ${row.fromIp} - ${row.toIp}`)
+      message.push(t('pages.admin.servers.playerActivity.actions.IPRANGEUNBAN', { fromIp: row.fromIp, toIp: row.toIp }))
       break
     case 'MUTE':
-      message.push('Muted')
+      message.push(t('pages.admin.servers.playerActivity.actions.MUTE'))
       break
     case 'IPMUTE':
-      message.push(`Muted ${row.fromIp}`)
+      message.push(t('pages.admin.servers.playerActivity.actions.IPMUTE', { ip: row.fromIp }))
       break
     case 'UNMUTE':
-      message.push('Unmuted')
+      message.push(t('pages.admin.servers.playerActivity.actions.UNMUTE'))
       break
     case 'IPUNMUTE':
-      message.push(`Unmuted ${row.fromIp}`)
+      message.push(t('pages.admin.servers.playerActivity.actions.IPUNMUTE', { ip: row.fromIp }))
       break
     case 'WARNING':
-      message.push('Warned')
+      message.push(t('pages.admin.servers.playerActivity.actions.WARNING'))
       break
     case 'NOTE':
-      message.push('Created a note for')
+      message.push(t('pages.admin.servers.playerActivity.actions.NOTE'))
       break
   }
 
@@ -102,7 +104,7 @@ const ActivityRow = ({ row, index }) => {
   }
 
   if (row?.expired && row?.expired !== 0 && !row?.type?.startsWith('UN')) {
-    message.push(<span key={'expired' + index + row.type + row.created}>for <span className='text-gray-400'><TimeDuration startTimestamp={row.created} endTimestamp={row.expired} /></span></span>)
+    message.push(<span key={'expired' + index + row.type + row.created}>{t('pages.admin.servers.playerActivity.for')} <span className='text-gray-400'><TimeDuration startTimestamp={row.created} endTimestamp={row.expired} /></span></span>)
   }
 
   if (row?.reason) {
@@ -156,6 +158,7 @@ const ActivityFilterTypes = ({ stateTypes, handleTypeChange }) => {
 }
 
 export default function PlayerActivity ({ server }) {
+  const t = useTranslations()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [tableState, setTableState] = useState({ serverId: server.id, limit: 100, actor: null, createdStart: null, createdEnd: null, types })
   const { errors, loading, data } = useApi({ query: !tableState.serverId ? null : query, variables: tableState })
@@ -180,7 +183,7 @@ export default function PlayerActivity ({ server }) {
     <>
       <NavigationOverlay drawerOpen={drawerOpen} setDrawerOpen={setDrawerOpen}>
         <NavigationOverlay.Header>
-          <h2 className='text-lg font-medium'>Filters</h2>
+          <h2 className='text-lg font-medium'>{t('pages.admin.servers.playerActivity.filters')}</h2>
         </NavigationOverlay.Header>
         <hr className='border-accent-200 w-full' />
         <NavigationOverlay.Body>
@@ -191,7 +194,7 @@ export default function PlayerActivity ({ server }) {
                   <h3 className='-mx-2 -my-3 flow-root'>
                     <Disclosure.Button className='px-2 py-3 w-full'>
                       <div className='flex items-center justify-between'>
-                        <span className='font-medium'>Start Date</span>
+                        <span className='font-medium'>{t('pages.admin.servers.playerActivity.startDate')}</span>
                         <span className='ml-6 flex items-center'>
                           {open
                             ? (
@@ -229,7 +232,7 @@ export default function PlayerActivity ({ server }) {
                   <h3 className='-mx-2 -my-3 flow-root'>
                     <Disclosure.Button className='px-2 py-3 w-full'>
                       <div className='flex items-center justify-between'>
-                        <span className='font-medium'>End Date</span>
+                        <span className='font-medium'>{t('pages.admin.servers.playerActivity.endDate')}</span>
                         <span className='ml-6 flex items-center'>
                           {open
                             ? (
@@ -270,12 +273,12 @@ export default function PlayerActivity ({ server }) {
               <PlayerSelector
                 multiple={false}
                 onChange={(actor) => setTableState({ ...tableState, actor })}
-                placeholder='Actor'
+                placeholder={t('pages.admin.servers.playerActivity.actor')}
                 value={tableState.actor}
               />
             </div>
             <div>
-              <Button className='px-4 py-2' disabled={!tableState.actor} onClick={() => setTableState({ ...tableState, actor: null })}>Clear</Button>
+              <Button className='px-4 py-2' disabled={!tableState.actor} onClick={() => setTableState({ ...tableState, actor: null })}>{t('pages.admin.servers.playerActivity.clear')}</Button>
             </div>
           </div>
         </NavigationOverlay.Body>
@@ -289,14 +292,14 @@ export default function PlayerActivity ({ server }) {
         </NavigationOverlay.Body>
       </NavigationOverlay>
       <div className='relative flex justify-between items-center pb-6 border-b border-gray-200'>
-        <h2 className='text-xl font-bold leading-none'>Activity Summary</h2>
+        <h2 className='text-xl font-bold leading-none'>{t('pages.admin.servers.playerActivity.summaryTitle')}</h2>
         <div className='flex items-center'>
           <button
             type='button'
             className='text-gray-400 hover:text-gray-500 lg:hidden'
             onClick={() => setDrawerOpen(true)}
           >
-            <span className='sr-only'>Filters</span>
+            <span className='sr-only'>{t('pages.admin.servers.playerActivity.filters')}</span>
             <MdFilterAlt className='w-6 h-6' />
           </button>
         </div>
@@ -307,9 +310,9 @@ export default function PlayerActivity ({ server }) {
           {data?.playerActivity?.records?.length === tableState.limit &&
             <div className='text-sm font-medium'>
               <Message warning>
-                <Message.Header>Warning</Message.Header>
+                <Message.Header>{t('common.warning')}</Message.Header>
                 <Message.List>
-                  <Message.Item>Results are limited, use the filters to see more</Message.Item>
+                  <Message.Item>{t('pages.admin.servers.playerActivity.limitWarning')}</Message.Item>
                 </Message.List>
               </Message>
             </div>}
@@ -325,7 +328,7 @@ export default function PlayerActivity ({ server }) {
             <PlayerSelector
               multiple={false}
               onChange={(actor) => setTableState({ ...tableState, actor })}
-              placeholder='Actor'
+              placeholder={t('pages.admin.servers.playerActivity.actor')}
               value={tableState.actor}
               clearable
             />

--- a/components/admin/servers/stats/ServerBanStats.js
+++ b/components/admin/servers/stats/ServerBanStats.js
@@ -2,10 +2,12 @@ import { useState } from 'react'
 import { format, formatDistance, fromUnixTime } from 'date-fns'
 import resolveConfig from 'tailwindcss/resolveConfig'
 import { BsChevronDown } from 'react-icons/bs'
+import { useTranslations } from 'next-intl'
 import ResponsiveLine from '../../../charts/ResponsiveLine'
 import Dropdown from '../../../Dropdown'
 import Loader from '../../../Loader'
 import { useApi } from '../../../../utils'
+import { useDateFnsLocale } from '../../../../utils/format-distance'
 import tailwindConfig from '../../../../tailwind.config'
 
 const fullConfig = resolveConfig(tailwindConfig)
@@ -24,17 +26,27 @@ query serverBanStats($id: ID!, $intervalDays: Int!) {
 }`
 
 export default function ServerBanStats ({ server }) {
+  const t = useTranslations()
+  const dateFnsLocale = useDateFnsLocale()
   const [intervalDays, setIntervalDays] = useState(7)
   const { loading, data, errors } = useApi({ query, variables: { id: server.id, intervalDays } })
 
   if (errors) return null
+
+  const formatChartDate = (timestamp) => {
+    try {
+      return format(fromUnixTime(timestamp), 'd MMM yyyy', dateFnsLocale ? { locale: dateFnsLocale } : undefined)
+    } catch {
+      return format(fromUnixTime(timestamp), 'd MMM yyyy')
+    }
+  }
 
   const chartData = [
     {
       id: 'bans',
       color: colour,
       data: (data?.serverBanStats?.totalHistory || []).map(row => ({
-        x: format(fromUnixTime(row.date), 'd MMM yyyy'),
+        x: formatChartDate(row.date),
         y: row.value
       }))
     }
@@ -43,17 +55,17 @@ export default function ServerBanStats ({ server }) {
   return (
     <div className='pt-5 bg-black shadow-md rounded-md w-80'>
       <div className='px-5 flex justify-between items-center text-sm text-gray-500'>
-        <h5 className='uppercase'>Bans</h5>
+        <h5 className='uppercase'>{t('pages.admin.servers.stats.bans')}</h5>
         <Dropdown
           trigger={({ onClickToggle }) => (
             <>
-              <a onClick={onClickToggle} className='hover:underline cursor-pointer'>Last {intervalDays} days <BsChevronDown className='inline' /></a>
+              <a onClick={onClickToggle} className='hover:underline cursor-pointer'>{t('pages.admin.servers.stats.lastDays', { days: intervalDays })} <BsChevronDown className='inline' /></a>
             </>
           )}
         >
-          <Dropdown.Item name='Last 7 days' onClick={() => setIntervalDays(7)} />
-          <Dropdown.Item name='Last 30 days' onClick={() => setIntervalDays(30)} />
-          <Dropdown.Item name='Last 90 days' onClick={() => setIntervalDays(90)} />
+          <Dropdown.Item name={t('pages.admin.servers.stats.lastDays', { days: 7 })} onClick={() => setIntervalDays(7)} />
+          <Dropdown.Item name={t('pages.admin.servers.stats.lastDays', { days: 30 })} onClick={() => setIntervalDays(30)} />
+          <Dropdown.Item name={t('pages.admin.servers.stats.lastDays', { days: 90 })} onClick={() => setIntervalDays(90)} />
         </Dropdown>
       </div>
       <div className='mt-2 flex flex-wrap justify-around'>
@@ -62,12 +74,12 @@ export default function ServerBanStats ({ server }) {
           <>
             <div className='text-center'>
               <h2 className='title-font font-medium text-xl'>{data.serverBanStats.total}</h2>
-              <p className='leading-relaxed text-sm'>Total</p>
+              <p className='leading-relaxed text-sm'>{t('pages.admin.servers.stats.total')}</p>
             </div>
             {!!data.serverBanStats?.averageLength &&
               <div className='text-center'>
                 <h2 className='title-font font-medium text-xl'>{formatDistance(0, data.serverBanStats.averageLength * 1000, { includeSeconds: true })}</h2>
-                <p className='leading-relaxed text-sm'>avg length</p>
+                <p className='leading-relaxed text-sm'>{t('pages.admin.servers.stats.averageLength')}</p>
               </div>}
           </>}
       </div>

--- a/components/admin/servers/stats/ServerMuteStats.js
+++ b/components/admin/servers/stats/ServerMuteStats.js
@@ -2,10 +2,12 @@ import { useState } from 'react'
 import { format, formatDistance, fromUnixTime } from 'date-fns'
 import resolveConfig from 'tailwindcss/resolveConfig'
 import { BsChevronDown } from 'react-icons/bs'
+import { useTranslations } from 'next-intl'
 import ResponsiveLine from '../../../charts/ResponsiveLine'
 import Dropdown from '../../../Dropdown'
 import Loader from '../../../Loader'
 import { useApi } from '../../../../utils'
+import { useDateFnsLocale } from '../../../../utils/format-distance'
 import tailwindConfig from '../../../../tailwind.config'
 
 const fullConfig = resolveConfig(tailwindConfig)
@@ -24,17 +26,27 @@ query serverMuteStats($id: ID!, $intervalDays: Int!) {
 }`
 
 export default function ServerMuteStats ({ server }) {
+  const t = useTranslations()
+  const dateFnsLocale = useDateFnsLocale()
   const [intervalDays, setIntervalDays] = useState(7)
   const { loading, data, errors } = useApi({ query, variables: { id: server.id, intervalDays } })
 
   if (errors) return null
+
+  const formatChartDate = (timestamp) => {
+    try {
+      return format(fromUnixTime(timestamp), 'd MMM yyyy', dateFnsLocale ? { locale: dateFnsLocale } : undefined)
+    } catch {
+      return format(fromUnixTime(timestamp), 'd MMM yyyy')
+    }
+  }
 
   const chartData = [
     {
       id: 'mutes',
       color: colour,
       data: (data?.serverMuteStats?.totalHistory || []).map(row => ({
-        x: format(fromUnixTime(row.date), 'd MMM yyyy'),
+        x: formatChartDate(row.date),
         y: row.value
       }))
     }
@@ -43,17 +55,17 @@ export default function ServerMuteStats ({ server }) {
   return (
     <div className='pt-5 bg-black shadow-md rounded-md w-80'>
       <div className='px-5 flex justify-between items-center text-sm text-gray-500'>
-        <h5 className='uppercase'>Mutes</h5>
+        <h5 className='uppercase'>{t('pages.admin.servers.stats.mutes')}</h5>
         <Dropdown
           trigger={({ onClickToggle }) => (
             <>
-              <a onClick={onClickToggle} className='hover:underline cursor-pointer'>Last {intervalDays} days <BsChevronDown className='inline' /></a>
+              <a onClick={onClickToggle} className='hover:underline cursor-pointer'>{t('pages.admin.servers.stats.lastDays', { days: intervalDays })} <BsChevronDown className='inline' /></a>
             </>
           )}
         >
-          <Dropdown.Item name='Last 7 days' onClick={() => setIntervalDays(7)} />
-          <Dropdown.Item name='Last 30 days' onClick={() => setIntervalDays(30)} />
-          <Dropdown.Item name='Last 90 days' onClick={() => setIntervalDays(90)} />
+          <Dropdown.Item name={t('pages.admin.servers.stats.lastDays', { days: 7 })} onClick={() => setIntervalDays(7)} />
+          <Dropdown.Item name={t('pages.admin.servers.stats.lastDays', { days: 30 })} onClick={() => setIntervalDays(30)} />
+          <Dropdown.Item name={t('pages.admin.servers.stats.lastDays', { days: 90 })} onClick={() => setIntervalDays(90)} />
         </Dropdown>
       </div>
       <div className='mt-2 flex flex-wrap justify-around'>
@@ -62,12 +74,12 @@ export default function ServerMuteStats ({ server }) {
           <>
             <div className='text-center'>
               <h2 className='title-font font-medium text-xl'>{data.serverMuteStats.total}</h2>
-              <p className='leading-relaxed text-sm'>Total</p>
+              <p className='leading-relaxed text-sm'>{t('pages.admin.servers.stats.total')}</p>
             </div>
             {!!data.serverMuteStats?.averageLength &&
               <div className='text-center'>
                 <h2 className='title-font font-medium text-xl'>{formatDistance(0, data.serverMuteStats.averageLength * 1000, { includeSeconds: true })}</h2>
-                <p className='leading-relaxed text-sm'>avg length</p>
+                <p className='leading-relaxed text-sm'>{t('pages.admin.servers.stats.averageLength')}</p>
               </div>}
           </>}
       </div>

--- a/components/admin/servers/stats/ServerReportStats.js
+++ b/components/admin/servers/stats/ServerReportStats.js
@@ -2,10 +2,12 @@ import { useState } from 'react'
 import { format, formatDistance, fromUnixTime } from 'date-fns'
 import resolveConfig from 'tailwindcss/resolveConfig'
 import { BsChevronDown } from 'react-icons/bs'
+import { useTranslations } from 'next-intl'
 import ResponsiveLine from '../../../charts/ResponsiveLine'
 import Dropdown from '../../../Dropdown'
 import Loader from '../../../Loader'
 import { useApi } from '../../../../utils'
+import { useDateFnsLocale } from '../../../../utils/format-distance'
 import tailwindConfig from '../../../../tailwind.config'
 
 const fullConfig = resolveConfig(tailwindConfig)
@@ -24,17 +26,27 @@ query serverReportStats($id: ID!, $intervalDays: Int!) {
 }`
 
 export default function ServerReportStats ({ server }) {
+  const t = useTranslations()
+  const dateFnsLocale = useDateFnsLocale()
   const [intervalDays, setIntervalDays] = useState(7)
   const { loading, data, errors } = useApi({ query, variables: { id: server.id, intervalDays } })
 
   if (errors) return null
+
+  const formatChartDate = (timestamp) => {
+    try {
+      return format(fromUnixTime(timestamp), 'd MMM yyyy', dateFnsLocale ? { locale: dateFnsLocale } : undefined)
+    } catch {
+      return format(fromUnixTime(timestamp), 'd MMM yyyy')
+    }
+  }
 
   const chartData = [
     {
       id: 'reports',
       color: colour,
       data: (data?.serverReportStats?.totalHistory || []).map(row => ({
-        x: format(fromUnixTime(row.date), 'd MMM yyyy'),
+        x: formatChartDate(row.date),
         y: row.value
       }))
     }
@@ -43,17 +55,17 @@ export default function ServerReportStats ({ server }) {
   return (
     <div className='pt-5 bg-black shadow-md rounded-md w-80'>
       <div className='px-5 flex justify-between items-center text-sm text-gray-500'>
-        <h5 className='uppercase'>Reports</h5>
+        <h5 className='uppercase'>{t('pages.admin.servers.stats.reports')}</h5>
         <Dropdown
           trigger={({ onClickToggle }) => (
             <>
-              <a onClick={onClickToggle} className='hover:underline cursor-pointer'>Last {intervalDays} days <BsChevronDown className='inline' /></a>
+              <a onClick={onClickToggle} className='hover:underline cursor-pointer'>{t('pages.admin.servers.stats.lastDays', { days: intervalDays })} <BsChevronDown className='inline' /></a>
             </>
           )}
         >
-          <Dropdown.Item name='Last 7 days' onClick={() => setIntervalDays(7)} />
-          <Dropdown.Item name='Last 30 days' onClick={() => setIntervalDays(30)} />
-          <Dropdown.Item name='Last 90 days' onClick={() => setIntervalDays(90)} />
+          <Dropdown.Item name={t('pages.admin.servers.stats.lastDays', { days: 7 })} onClick={() => setIntervalDays(7)} />
+          <Dropdown.Item name={t('pages.admin.servers.stats.lastDays', { days: 30 })} onClick={() => setIntervalDays(30)} />
+          <Dropdown.Item name={t('pages.admin.servers.stats.lastDays', { days: 90 })} onClick={() => setIntervalDays(90)} />
         </Dropdown>
       </div>
       <div className='mt-2 flex flex-wrap justify-around'>
@@ -62,12 +74,12 @@ export default function ServerReportStats ({ server }) {
           <>
             <div className='text-center'>
               <h2 className='title-font font-medium text-xl'>{data.serverReportStats.total}</h2>
-              <p className='leading-relaxed text-sm'>Total</p>
+              <p className='leading-relaxed text-sm'>{t('pages.admin.servers.stats.total')}</p>
             </div>
             {!!data.serverReportStats?.averageLength &&
               <div className='text-center'>
                 <h2 className='title-font font-medium text-xl'>{formatDistance(0, data.serverReportStats.averageLength * 1000, { includeSeconds: true })}</h2>
-                <p className='leading-relaxed text-sm'>avg resolution</p>
+                <p className='leading-relaxed text-sm'>{t('pages.admin.servers.stats.averageResolution')}</p>
               </div>}
           </>}
       </div>

--- a/components/admin/servers/stats/ServerWarningStats.js
+++ b/components/admin/servers/stats/ServerWarningStats.js
@@ -2,10 +2,12 @@ import { useState } from 'react'
 import { format, formatDistance, fromUnixTime } from 'date-fns'
 import resolveConfig from 'tailwindcss/resolveConfig'
 import { BsChevronDown } from 'react-icons/bs'
+import { useTranslations } from 'next-intl'
 import ResponsiveLine from '../../../charts/ResponsiveLine'
 import Dropdown from '../../../Dropdown'
 import Loader from '../../../Loader'
 import { useApi } from '../../../../utils'
+import { useDateFnsLocale } from '../../../../utils/format-distance'
 import tailwindConfig from '../../../../tailwind.config'
 
 const fullConfig = resolveConfig(tailwindConfig)
@@ -24,17 +26,27 @@ query serverWarningStats($id: ID!, $intervalDays: Int!) {
 }`
 
 export default function ServerWarningStats ({ server }) {
+  const t = useTranslations()
+  const dateFnsLocale = useDateFnsLocale()
   const [intervalDays, setIntervalDays] = useState(7)
   const { loading, data, errors } = useApi({ query, variables: { id: server.id, intervalDays } })
 
   if (errors) return null
+
+  const formatChartDate = (timestamp) => {
+    try {
+      return format(fromUnixTime(timestamp), 'd MMM yyyy', dateFnsLocale ? { locale: dateFnsLocale } : undefined)
+    } catch {
+      return format(fromUnixTime(timestamp), 'd MMM yyyy')
+    }
+  }
 
   const chartData = [
     {
       id: 'warnings',
       color: colour,
       data: (data?.serverWarningStats?.totalHistory || []).map(row => ({
-        x: format(fromUnixTime(row.date), 'd MMM yyyy'),
+        x: formatChartDate(row.date),
         y: row.value
       }))
     }
@@ -43,17 +55,17 @@ export default function ServerWarningStats ({ server }) {
   return (
     <div className='pt-5 bg-black shadow-md rounded-md w-80'>
       <div className='px-5 flex justify-between items-center text-sm text-gray-500'>
-        <h5 className='uppercase'>Warnings</h5>
+        <h5 className='uppercase'>{t('pages.admin.servers.stats.warnings')}</h5>
         <Dropdown
           trigger={({ onClickToggle }) => (
             <>
-              <a onClick={onClickToggle} className='hover:underline cursor-pointer'>Last {intervalDays} days <BsChevronDown className='inline' /></a>
+              <a onClick={onClickToggle} className='hover:underline cursor-pointer'>{t('pages.admin.servers.stats.lastDays', { days: intervalDays })} <BsChevronDown className='inline' /></a>
             </>
           )}
         >
-          <Dropdown.Item name='Last 7 days' onClick={() => setIntervalDays(7)} />
-          <Dropdown.Item name='Last 30 days' onClick={() => setIntervalDays(30)} />
-          <Dropdown.Item name='Last 90 days' onClick={() => setIntervalDays(90)} />
+          <Dropdown.Item name={t('pages.admin.servers.stats.lastDays', { days: 7 })} onClick={() => setIntervalDays(7)} />
+          <Dropdown.Item name={t('pages.admin.servers.stats.lastDays', { days: 30 })} onClick={() => setIntervalDays(30)} />
+          <Dropdown.Item name={t('pages.admin.servers.stats.lastDays', { days: 90 })} onClick={() => setIntervalDays(90)} />
         </Dropdown>
       </div>
       <div className='mt-2 flex flex-wrap justify-around'>
@@ -62,12 +74,12 @@ export default function ServerWarningStats ({ server }) {
           <>
             <div className='text-center'>
               <h2 className='title-font font-medium text-xl'>{data.serverWarningStats.total}</h2>
-              <p className='leading-relaxed text-sm'>Total</p>
+              <p className='leading-relaxed text-sm'>{t('pages.admin.servers.stats.total')}</p>
             </div>
             {!!data.serverWarningStats?.averageLength &&
               <div className='text-center'>
                 <h2 className='title-font font-medium text-xl'>{formatDistance(0, data.serverWarningStats.averageLength * 1000, { includeSeconds: true })}</h2>
-                <p className='leading-relaxed text-sm'>avg length</p>
+                <p className='leading-relaxed text-sm'>{t('pages.admin.servers.stats.averageLength')}</p>
               </div>}
           </>}
       </div>

--- a/components/admin/webhooks/JsonPreview.js
+++ b/components/admin/webhooks/JsonPreview.js
@@ -1,6 +1,8 @@
 import fillTemplate from 'es6-dynamic-template'
+import { useTranslations } from 'next-intl'
 
 export default function DiscordPreview ({ json, variables }) {
+  const t = useTranslations('pages.admin.webhooks')
   if (!json) return null
 
   let content = json
@@ -12,7 +14,7 @@ export default function DiscordPreview ({ json, variables }) {
   try {
     content = JSON.parse(content)
   } catch (e) {
-    return <div className='text-red-500'>Invalid JSON</div>
+    return <div className='text-red-500'>{t('invalidJson')}</div>
   }
 
   return (

--- a/components/admin/webhooks/WebhookDeliveryItem.js
+++ b/components/admin/webhooks/WebhookDeliveryItem.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import { Time } from '../../Time'
 import { TabGroup, TabList, TabPanel } from '@headlessui/react'
 import Tab from '../../Tab'
@@ -16,6 +17,7 @@ const HttpHeader = ({ name, value }) => (
 )
 
 export default function WebhookDeliveryItem ({ id, content, response, error, created }) {
+  const t = useTranslations()
   const buttonContent = (
     <div className='flex justify-between items-center' data-cy='webhook-delivery-summary' data-cy-status={response?.status || 'error'}>
       <div>
@@ -34,8 +36,8 @@ export default function WebhookDeliveryItem ({ id, content, response, error, cre
       <AnimatedDisclosure buttonContent={buttonContent} defaultOpen={false}>
         <TabGroup>
           <TabList>
-            <Tab>Request</Tab>
-            <Tab>Response {response?.status && (
+            <Tab>{t('pages.admin.webhooks.delivery.request')}</Tab>
+            <Tab>{t('pages.admin.webhooks.delivery.response')} {response?.status && (
               <Badge
                 data-cy='webhook-delivery-status-badge'
                 className={clsx({
@@ -51,14 +53,14 @@ export default function WebhookDeliveryItem ({ id, content, response, error, cre
           <TabPanels>
             <TabPanel>
               <div className='flex flex-col gap-2'>
-                <h2 className='mt-2 text-sm font-bold'>Headers</h2>
+                <h2 className='mt-2 text-sm font-bold'>{t('pages.admin.webhooks.delivery.headers')}</h2>
                 <div className='bg-gray-800 p-2 rounded-lg border-gray-700 border'>
                   <HttpHeader name='Accept' value='application/json' />
                   <HttpHeader name='Content-Type' value='application/json' />
                 </div>
                 {content && (
                   <>
-                    <h2 className='mt-2 text-sm font-bold'>Payload</h2>
+                    <h2 className='mt-2 text-sm font-bold'>{t('pages.admin.webhooks.delivery.payload')}</h2>
                     <div className='bg-gray-800 p-2 rounded-lg border-gray-700 border'>
                       <pre className='text-sm'>{JSON.stringify(JSON.parse(content), null, 2)}</pre>
                     </div>
@@ -72,7 +74,7 @@ export default function WebhookDeliveryItem ({ id, content, response, error, cre
                   <>
                     {response.headers && (
                       <>
-                        <h2 className='mt-2 text-sm font-bold'>Headers</h2>
+                        <h2 className='mt-2 text-sm font-bold'>{t('pages.admin.webhooks.delivery.headers')}</h2>
                         <div className='bg-gray-800 p-2 rounded-lg border-gray-700 border'>
                           {Object.keys(response.headers).map((name, index) => (
                             <HttpHeader key={index} name={name} value={response.headers[name]} />
@@ -82,7 +84,7 @@ export default function WebhookDeliveryItem ({ id, content, response, error, cre
                     )}
                     {response.body && (
                       <>
-                        <h2 className='mt-2 text-sm font-bold'>Body</h2>
+                        <h2 className='mt-2 text-sm font-bold'>{t('pages.admin.webhooks.delivery.body')}</h2>
                         <div className='bg-gray-800 p-2 rounded-lg border-gray-700 border'>
                           <pre className='text-sm'>{JSON.stringify(response.body, null, 2)}</pre>
                         </div>
@@ -92,7 +94,7 @@ export default function WebhookDeliveryItem ({ id, content, response, error, cre
                 )}
                 {error && (
                   <>
-                    <h2 className='mt-2 text-sm font-bold'>Error</h2>
+                    <h2 className='mt-2 text-sm font-bold'>{t('pages.admin.webhooks.delivery.error')}</h2>
                     <div className='bg-gray-800 p-2 rounded-lg border-gray-700 border'>
                       <pre className='text-sm'>{error?.cause?.message}</pre>
                     </div>

--- a/components/admin/webhooks/WebhookDiscordForm.js
+++ b/components/admin/webhooks/WebhookDiscordForm.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useForm, Controller } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Button from '../../Button'
 import PageHeader from '../AdminHeader'
 import ErrorMessages from '../../ErrorMessages'
@@ -13,6 +14,7 @@ import DiscordPreview from './DiscordPreview'
 import { AiOutlineCopy } from 'react-icons/ai'
 
 export default function WebhookDiscordForm ({ onFinished, query, parseVariables, eventTypes, defaults = {} }) {
+  const t = useTranslations()
   const errorRef = useRef(null)
   const { handleSubmit, formState, control, register, watch } = useForm({
     defaultValues: {
@@ -58,7 +60,7 @@ export default function WebhookDiscordForm ({ onFinished, query, parseVariables,
     <div className='grid grid-cols-1 md:grid-cols-12 gap-6'>
       <form onSubmit={handleSubmit(onSubmit)} className='col-span-3' data-cy='webhook-form' data-cy-template='DISCORD'>
         <ErrorMessages ref={errorRef} errors={errors} className='shrink' />
-        <PageHeader title='Event Type' className='!text-xl' />
+        <PageHeader title={t('pages.admin.webhooks.form.eventType')} className='!text-xl' />
         <div data-cy='webhook-type'>
           <Controller
             name='type'
@@ -74,29 +76,29 @@ export default function WebhookDiscordForm ({ onFinished, query, parseVariables,
                                    />}
           />
         </div>
-        <PageHeader title='Server (optional)' className='!text-xl' />
+        <PageHeader title={t('pages.admin.webhooks.form.serverOptional')} className='!text-xl' />
         <div data-cy='webhook-server'>
           <Controller
             name='serverId'
             control={control}
             defaultValue={false}
-            render={({ field }) => <ServerSelector isClearable className='mb-6' placeholder='Server' {...field} />}
+            render={({ field }) => <ServerSelector isClearable className='mb-6' placeholder={t('pages.admin.webhooks.form.server')} {...field} />}
           />
         </div>
-        <PageHeader title='URL' className='!text-xl' />
+        <PageHeader title={t('pages.admin.webhooks.form.url')} className='!text-xl' />
         <Input
           required
-          placeholder='https://discord.com/webhook'
+          placeholder={t('pages.admin.webhooks.form.urlPlaceholderDiscord')}
           icon={<TbHttpPost />}
           type='url'
           data-cy='webhook-url'
           {...register('url')}
         />
-        <Button data-cy='submit-webhook-form' disabled={isSubmitting} loading={loading}>Save</Button>
+        <Button data-cy='submit-webhook-form' disabled={isSubmitting} loading={loading}>{t('common.save')}</Button>
       </form>
       <div className='col-span-5'>
-        <PageHeader title='Content Template' className='!text-xl'>
-          <p className='text-sm'>Use the variables defined to customize the content</p>
+        <PageHeader title={t('pages.admin.webhooks.form.contentTemplate')} className='!text-xl'>
+          <p className='text-sm'>{t('pages.admin.webhooks.form.contentHint')}</p>
         </PageHeader>
         <TextArea
           required
@@ -105,7 +107,7 @@ export default function WebhookDiscordForm ({ onFinished, query, parseVariables,
           data-cy='webhook-content-template'
           {...register('contentTemplate')}
         />
-        <PageHeader title='Available Variables' className='!text-xl' />
+        <PageHeader title={t('pages.admin.webhooks.form.availableVariables')} className='!text-xl' />
         {variables && (
           <div className='flex flex-col'>
             {Object.keys(variables).map(key => (
@@ -134,7 +136,7 @@ export default function WebhookDiscordForm ({ onFinished, query, parseVariables,
         )}
       </div>
       <div className='col-span-4'>
-        <PageHeader title='Preview' className='!text-xl' />
+        <PageHeader title={t('pages.admin.webhooks.form.preview')} className='!text-xl' />
         <DiscordPreview json={watch('contentTemplate')} variables={variables} />
       </div>
     </div>

--- a/components/admin/webhooks/WebhookForm.js
+++ b/components/admin/webhooks/WebhookForm.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useForm, Controller } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Button from '../../Button'
 import PageHeader from '../AdminHeader'
 import ErrorMessages from '../../ErrorMessages'
@@ -13,6 +14,7 @@ import JsonPreview from './JsonPreview'
 import { AiOutlineCopy } from 'react-icons/ai'
 
 export default function WebhookCustomForm ({ onFinished, query, parseVariables, eventTypes, defaults = {} }) {
+  const t = useTranslations()
   const errorRef = useRef(null)
   const { handleSubmit, formState, control, register, watch } = useForm({
     defaultValues: {
@@ -58,7 +60,7 @@ export default function WebhookCustomForm ({ onFinished, query, parseVariables, 
     <div className='grid grid-cols-1 md:grid-cols-12 gap-6'>
       <form onSubmit={handleSubmit(onSubmit)} className='col-span-3' data-cy='webhook-form' data-cy-template='CUSTOM'>
         <ErrorMessages ref={errorRef} errors={errors} className='shrink' />
-        <PageHeader title='Event Type' className='!text-xl' />
+        <PageHeader title={t('pages.admin.webhooks.form.eventType')} className='!text-xl' />
         <div data-cy='webhook-type'>
           <Controller
             name='type'
@@ -74,29 +76,29 @@ export default function WebhookCustomForm ({ onFinished, query, parseVariables, 
                                    />}
           />
         </div>
-        <PageHeader title='Server (optional)' className='!text-xl' />
+        <PageHeader title={t('pages.admin.webhooks.form.serverOptional')} className='!text-xl' />
         <div data-cy='webhook-server'>
           <Controller
             name='serverId'
             control={control}
             defaultValue={false}
-            render={({ field }) => <ServerSelector isClearable className='mb-6' placeholder='Server' {...field} />}
+            render={({ field }) => <ServerSelector isClearable className='mb-6' placeholder={t('pages.admin.webhooks.form.server')} {...field} />}
           />
         </div>
-        <PageHeader title='URL' className='!text-xl' />
+        <PageHeader title={t('pages.admin.webhooks.form.url')} className='!text-xl' />
         <Input
           required
-          placeholder='https://example.com/webhook'
+          placeholder={t('pages.admin.webhooks.form.urlPlaceholderCustom')}
           icon={<TbHttpPost />}
           type='url'
           data-cy='webhook-url'
           {...register('url')}
         />
-        <Button data-cy='submit-webhook-form' disabled={isSubmitting} loading={loading}>Save</Button>
+        <Button data-cy='submit-webhook-form' disabled={isSubmitting} loading={loading}>{t('common.save')}</Button>
       </form>
       <div className='col-span-5'>
-        <PageHeader title='Content Template' className='!text-xl'>
-          <p className='text-sm'>Use the variables defined to customize the content</p>
+        <PageHeader title={t('pages.admin.webhooks.form.contentTemplate')} className='!text-xl'>
+          <p className='text-sm'>{t('pages.admin.webhooks.form.contentHint')}</p>
         </PageHeader>
         <TextArea
           required
@@ -105,7 +107,7 @@ export default function WebhookCustomForm ({ onFinished, query, parseVariables, 
           data-cy='webhook-content-template'
           {...register('contentTemplate')}
         />
-        <PageHeader title='Available Variables' className='!text-xl' />
+        <PageHeader title={t('pages.admin.webhooks.form.availableVariables')} className='!text-xl' />
         {variables && (
           <div className='flex flex-col'>
             {Object.keys(variables).map(key => (
@@ -134,7 +136,7 @@ export default function WebhookCustomForm ({ onFinished, query, parseVariables, 
         )}
       </div>
       <div className='col-span-4'>
-        <PageHeader title='Preview' className='!text-xl' />
+        <PageHeader title={t('pages.admin.webhooks.form.preview')} className='!text-xl' />
         <JsonPreview json={watch('contentTemplate')} variables={variables} />
       </div>
     </div>

--- a/components/admin/webhooks/WebhookItem.js
+++ b/components/admin/webhooks/WebhookItem.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import { BiServer } from 'react-icons/bi'
 import { MdSettings } from 'react-icons/md'
 import { FaPencilAlt, FaDiscord } from 'react-icons/fa'
@@ -26,6 +27,7 @@ const query = `mutation sendTestWebhook($id: ID!, $variables: JSONObject!) {
 }`
 
 export default function WebhookItem ({ row, onDeleted }) {
+  const t = useTranslations()
   const [open, setOpen] = useState(false)
   const [testWebhookOpen, setTestWebhookOpen] = useState(false)
   const { load, loading, errors, data } = useMutateApi({
@@ -63,19 +65,19 @@ export default function WebhookItem ({ row, onDeleted }) {
   return (
     <div className='hover:bg-gray-900 group border-b border-gray-700' data-cy='webhook-item' data-cy-webhook-id={row.id} data-cy-template={row?.templateType}>
       <Modal
-        title='Delete webhook'
-        confirmButton='Delete'
+        title={t('pages.admin.webhooks.deleteTitle')}
+        confirmButton={t('common.delete')}
         open={open}
         onConfirm={handleConfirmDelete}
         onCancel={handleDeleteCancel}
         loading={loading}
       >
         <ErrorMessages errors={errors} />
-        <p className='pb-1'>Are you sure you want to delete this webhook?</p>
-        <p className='pb-1'>This action cannot be undone</p>
+        <p className='pb-1'>{t('pages.admin.webhooks.deleteConfirm')}</p>
+        <p className='pb-1'>{t('pages.punishment.actionUndoable')}</p>
       </Modal>
       <Modal
-        title='Test webhook'
+        title={t('pages.admin.webhooks.testTitle')}
         open={testWebhookOpen}
         onCancel={handleTestWebhookCancel}
       >
@@ -112,15 +114,15 @@ export default function WebhookItem ({ row, onDeleted }) {
       </div>
       <div className='flex flex-row gap-6 md:hidden mb-2'>
         <div>
-          <Button data-cy='webhook-test-mobile' className='bg-accent-600 hover:bg-accent-700 text-sm px-4 py-2' onClick={showTestWebhook}><BsFillSendFill /> Test</Button>
+          <Button data-cy='webhook-test-mobile' className='bg-accent-600 hover:bg-accent-700 text-sm px-4 py-2' onClick={showTestWebhook}><BsFillSendFill /> {t('common.test')}</Button>
         </div>
         <div>
           <Link href={`/admin/webhooks/${row.id}`} passHref>
-            <Button data-cy='webhook-edit-mobile' className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><FaPencilAlt /> Edit</Button>
+            <Button data-cy='webhook-edit-mobile' className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><FaPencilAlt /> {t('common.edit')}</Button>
           </Link>
         </div>
         <div>
-          <Button data-cy='webhook-delete-mobile' className='bg-red-600 hover:bg-red-700 text-sm px-4 py-2' onClick={showConfirmDelete}><BsTrash /> Delete</Button>
+          <Button data-cy='webhook-delete-mobile' className='bg-red-600 hover:bg-red-700 text-sm px-4 py-2' onClick={showConfirmDelete}><BsTrash /> {t('common.delete')}</Button>
         </div>
       </div>
     </div>

--- a/components/admin/webhooks/WebhookTestForm.js
+++ b/components/admin/webhooks/WebhookTestForm.js
@@ -1,9 +1,11 @@
 import { useForm } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Button from '../../Button'
 import Input from '../../Input'
 import { useMutateApi } from '../../../utils'
 
 export default function WebhookTestForm ({ query, id, variables = {} }) {
+  const t = useTranslations()
   const { handleSubmit, register } = useForm({ defaultValues: variables })
   const { load, loading, data, errors } = useMutateApi({ query })
 
@@ -23,20 +25,21 @@ export default function WebhookTestForm ({ query, id, variables = {} }) {
           />
         </div>
       ))}
-      <Button data-cy='submit-webhook-test' type='submit' disabled={loading} loading={loading}>Send</Button>
+      <Button data-cy='submit-webhook-test' type='submit' disabled={loading} loading={loading}>{t('common.send')}</Button>
       {data && <WebhookResponse {...data.sendTestWebhook} />}
-      {errors && <div className='mt-4 text-red-500' data-cy='webhook-test-error'>Error sending webhook: {JSON.stringify(errors, null, 2)}</div>}
+      {errors && <div className='mt-4 text-red-500' data-cy='webhook-test-error'>{t('pages.admin.webhooks.test.errorPrefix')}: {JSON.stringify(errors, null, 2)}</div>}
     </form>
   )
 }
 
 const WebhookResponse = ({ content, response }) => {
+  const t = useTranslations()
   return (
     <div className='mt-3 overflow-auto' data-cy='webhook-test-response'>
       <h2 className='font-semibold' data-cy='webhook-test-response-status'>{response.status} {response.statusText}</h2>
-      <pre>Body {JSON.stringify(response.body, null, 2)}</pre>
-      <pre>Headers {JSON.stringify(response.headers, null, 2)}</pre>
-      <pre>Content {content}</pre>
+      <pre>{t('pages.admin.webhooks.delivery.body')} {JSON.stringify(response.body, null, 2)}</pre>
+      <pre>{t('pages.admin.webhooks.delivery.headers')} {JSON.stringify(response.headers, null, 2)}</pre>
+      <pre>{t('pages.admin.webhooks.test.content')} {content}</pre>
     </div>
   )
 }

--- a/components/appeal/AppealPunishment.js
+++ b/components/appeal/AppealPunishment.js
@@ -2,11 +2,13 @@ import ActivityBadge from '../admin/servers/ActivityBadge'
 import Avatar from '../Avatar'
 import Link from 'next/link'
 import { BiServer } from 'react-icons/bi'
+import { useTranslations } from 'next-intl'
 import { formatTimestamp } from '../../utils'
 import Button from '../Button'
-import AnimatedDisclosure from '../AnimatedDisclosure' // Adjust the import path as necessary
+import AnimatedDisclosure from '../AnimatedDisclosure'
 
 export default function AppealPunishment ({ punishment, appealable, open }) {
+  const t = useTranslations()
   const buttonContent = (
     <div className='w-full flex flex-row items-center gap-4'>
       <Avatar uuid={punishment.actor.id} height='54' width='54' />
@@ -30,7 +32,7 @@ export default function AppealPunishment ({ punishment, appealable, open }) {
       {appealable && (
         <Link href={`/appeal/punishment/${punishment.server.id}/${punishment.type}/${punishment.id}/`} passHref>
           <Button className='mt-4'>
-            Appeal
+            {t('pages.punishment.appeal')}
           </Button>
         </Link>
       )}

--- a/components/appeal/PlayerAppealForm.js
+++ b/components/appeal/PlayerAppealForm.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useForm, Controller } from 'react-hook-form'
+import { useTranslations } from 'next-intl'
 import Button from '../Button'
 import TextArea from '../TextArea'
 import ErrorMessages from '../ErrorMessages'
@@ -9,6 +10,7 @@ import InputCharCounter from '../InputCharCounter'
 import CommentWithUpload, { AttachButton } from '../CommentWithUpload'
 
 export default function PlayerAppealForm ({ actor, reason, expires, created, server, type, onFinished, parseVariables, canUpload = false }) {
+  const t = useTranslations()
   const { handleSubmit, formState, control, watch } = useForm({ defaultValues: { reason: '' } })
   const watchReason = watch('reason')
   const { isSubmitting } = formState
@@ -50,10 +52,10 @@ export default function PlayerAppealForm ({ actor, reason, expires, created, ser
                 {...field}
                 required
                 rows={6}
-                label='Why should this punishment be removed?'
+                label={t('pages.appeal.reasonLabel')}
                 minLength={20}
                 maxLength={2000}
-                placeholder='Explain why this punishment should be removed...'
+                placeholder={t('pages.appeal.reasonPlaceholder')}
                 documents={documentIds}
                 onDocumentsChange={setDocumentIds}
                 maxFiles={5}
@@ -78,7 +80,7 @@ export default function PlayerAppealForm ({ actor, reason, expires, created, ser
                   {...field}
                   required
                   rows={6}
-                  label='Why should this punishment be removed?'
+                  label={t('pages.appeal.reasonLabel')}
                   minLength={20}
                   maxLength={2000}
                   className='!-mb-6'
@@ -89,7 +91,7 @@ export default function PlayerAppealForm ({ actor, reason, expires, created, ser
           </>
           )}
       <Button data-cy='submit-appeal' disabled={isSubmitting || watchReason.length < 20} loading={isSubmitting}>
-        Appeal
+        {t('pages.punishment.appeal')}
       </Button>
     </form>
   )

--- a/components/appeal/PunishmentPicker.js
+++ b/components/appeal/PunishmentPicker.js
@@ -3,6 +3,7 @@ import { useApi, useUser } from '../../utils'
 import Button from '../Button'
 import { useMemo, useState } from 'react'
 import clsx from 'clsx'
+import { useTranslations } from 'next-intl'
 import AppealPunishment from './AppealPunishment'
 
 const query = `
@@ -57,13 +58,14 @@ query playerBans($id: UUID!) {
   }
 }`
 
-const types = [
-  { type: 'ban', label: 'Ban', colours: 'bg-red-800 hover:bg-red-900' },
-  { type: 'mute', label: 'Mute', colours: 'bg-indigo-800 hover:bg-indigo-900' },
-  { type: 'warning', label: 'Warning', colours: 'bg-amber-800 hover:bg-amber-900' }
+const typesConfig = [
+  { type: 'ban', colours: 'bg-red-800 hover:bg-red-900' },
+  { type: 'mute', colours: 'bg-indigo-800 hover:bg-indigo-900' },
+  { type: 'warning', colours: 'bg-amber-800 hover:bg-amber-900' }
 ]
 
 export default function PunishmentPicker () {
+  const t = useTranslations()
   const { user } = useUser()
   const { loading, data } = useApi({ query, variables: { id: user?.id } })
   const [activeFilter, setActiveFilter] = useState(['ban', 'mute', 'warning'])
@@ -101,14 +103,14 @@ export default function PunishmentPicker () {
       <AppealPunishment punishment={row} appealable />
     </div>
   ))
-  const filters = useMemo(() => types.map(({ type, label, colours }) => (
+  const filters = useMemo(() => typesConfig.map(({ type, colours }) => (
     <Button
       key={type}
       className={clsx(colours, { 'border-opacity-0 opacity-50': !activeFilter.includes(type) })}
       onClick={() => toggleFilter(type)}
       data-cy={`punishment-picker-filter-${type}`}
     >
-      {label}
+      {t(`pages.player.actions.${type}`)}
     </Button>
   )), [activeFilter])
 
@@ -123,10 +125,10 @@ export default function PunishmentPicker () {
         {(!data || !rows.length)
           ? (
             <div data-cy='punishment-picker-empty'>
-              <h2 className='text-center text-base font-semibold leading-relaxed pb-1'>No punishments founds</h2>
-              <p className='text-center text-sm font-normal leading-snug pb-4'>Try changing your filters</p>
+              <h2 className='text-center text-base font-semibold leading-relaxed pb-1'>{t('pages.appeal.noPunishments')}</h2>
+              <p className='text-center text-sm font-normal leading-snug pb-4'>{t('pages.appeal.tryChangingFilters')}</p>
               <div className='flex gap-3'>
-                <Button onClick={() => setActiveFilter(['ban', 'mute', 'warning'])} data-cy='punishment-picker-clear-filters'>Clear filters</Button>
+                <Button onClick={() => setActiveFilter(['ban', 'mute', 'warning'])} data-cy='punishment-picker-clear-filters'>{t('pages.appeal.clearFilters')}</Button>
               </div>
             </div>
             )

--- a/components/appeals/PlayerAppealActions.js
+++ b/components/appeals/PlayerAppealActions.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import { useUser } from '../../utils'
 import PlayerAppealActionDelete from './actions/PlayerAppealActionDelete'
 import PlayerAppealActionUpdate from './actions/PlayerAppealActionUpdate'
@@ -72,6 +73,7 @@ const createUpdateQuery = (mutation, input) => `mutation ${mutation}($id: ID!, $
 }`
 
 export default function PlayerAppealActions ({ appeal, server, onAction }) {
+  const t = useTranslations('pages.appeals.actions')
   const { user, hasServerPermission } = useUser()
 
   switch (appeal.punishmentType) {
@@ -86,7 +88,7 @@ export default function PlayerAppealActions ({ appeal, server, onAction }) {
           {canUpdate &&
             <PlayerAppealActionUpdate
               appeal={appeal}
-              title='Edit Ban'
+              title={t('editBan')}
               type='ban'
               query={createUpdateQuery('resolveAppealUpdateBan', 'UpdatePlayerBanInput')}
               onUpdated={onAction}
@@ -94,7 +96,7 @@ export default function PlayerAppealActions ({ appeal, server, onAction }) {
           {canDelete &&
             <PlayerAppealActionDelete
               appeal={appeal}
-              title='Unban'
+              title={t('unban')}
               type='ban'
               query={createDeleteQuery('resolveAppealDeleteBan')}
               onDeleted={data => onAction(data.resolveAppealDeleteBan)}
@@ -113,7 +115,7 @@ export default function PlayerAppealActions ({ appeal, server, onAction }) {
           {canUpdate &&
             <PlayerAppealActionUpdate
               appeal={appeal}
-              title='Edit Mute'
+              title={t('editMute')}
               type='mute'
               query={createUpdateQuery('resolveAppealUpdateMute', 'UpdatePlayerMuteInput')}
               onUpdated={onAction}
@@ -121,7 +123,7 @@ export default function PlayerAppealActions ({ appeal, server, onAction }) {
           {canDelete &&
             <PlayerAppealActionDelete
               appeal={appeal}
-              title='Unmute'
+              title={t('unmute')}
               type='mute'
               query={createDeleteQuery('resolveAppealDeleteMute')}
               onDeleted={data => onAction(data.resolveAppealDeleteMute)}
@@ -140,7 +142,7 @@ export default function PlayerAppealActions ({ appeal, server, onAction }) {
           {canUpdate &&
             <PlayerAppealActionUpdate
               appeal={appeal}
-              title='Edit Warning'
+              title={t('editWarning')}
               type='warning'
               query={createUpdateQuery('resolveAppealUpdateWarning', 'UpdatePlayerWarningInput')}
               onUpdated={onAction}
@@ -148,7 +150,7 @@ export default function PlayerAppealActions ({ appeal, server, onAction }) {
           {canDelete &&
             <PlayerAppealActionDelete
               appeal={appeal}
-              title='Delete warning'
+              title={t('deleteWarning')}
               type='warning'
               query={createDeleteQuery('resolveAppealDeleteWarning')}
               onDeleted={data => onAction(data.resolveAppealDeleteWarning)}

--- a/components/appeals/PlayerAppealAssign.js
+++ b/components/appeals/PlayerAppealAssign.js
@@ -1,10 +1,12 @@
 import { useEffect } from 'react'
+import { useTranslations } from 'next-intl'
 import Loader from '../Loader'
 import PlayerSelector from '../admin/PlayerSelector'
 import { useMutateApi } from '../../utils'
 import ErrorMessages from '../ErrorMessages'
 
 export default function PlayerAppealAssign ({ id, player, onChange }) {
+  const t = useTranslations('forms')
   const { data, loading, load, errors } = useMutateApi({
     query: /* GraphQL */ `
       mutation assignAppeal($id: ID!,$player: UUID!) {
@@ -67,7 +69,7 @@ export default function PlayerAppealAssign ({ id, player, onChange }) {
         key={player?.id}
         multiple={false}
         onChange={handleChange}
-        placeholder='Search by player name'
+        placeholder={t('playerSelectorPlaceholder')}
         defaultValue={player ? ({ value: player.id, label: <PlayerSelector.Label player={player} /> }) : null}
       />
     </>

--- a/components/appeals/PlayerAppealComment.js
+++ b/components/appeals/PlayerAppealComment.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import ErrorMessages from '../ErrorMessages'
 import Modal from '../Modal'
 import { fromNow, useMutateApi } from '../../utils'
@@ -7,6 +8,7 @@ import Avatar from '../Avatar'
 import DocumentGallery from '../DocumentGallery'
 
 export default function PlayerAppealComment ({ id, actor, created, content, acl, documents, onDelete, onDocumentDelete }) {
+  const t = useTranslations()
   const [open, setOpen] = useState(false)
   const { load, data, loading, errors } = useMutateApi({
     query: `mutation deleteAppealComment($id: ID!) {
@@ -42,33 +44,31 @@ export default function PlayerAppealComment ({ id, actor, created, content, acl,
         <Avatar uuid={actor.id} width={40} height={40} className='mx-1 inline-block relative' />
       </Link>
       <Modal
-        title='Delete comment'
-        confirmButton='Delete'
+        title={t('pages.appeals.deleteCommentTitle')}
+        confirmButton={t('common.delete')}
         open={open}
         onConfirm={handleConfirmDelete}
         onCancel={handleDeleteCancel}
         loading={loading}
       >
         <ErrorMessages errors={errors} />
-        <p className='pb-1'>Are you sure you want to delete this comment?</p>
-        <p className='pb-1'>This action cannot be undone</p>
+        <p className='pb-1'>{t('pages.appeals.deleteCommentConfirm')}</p>
+        <p className='pb-1'>{t('pages.punishment.actionUndoable')}</p>
       </Modal>
       <div className='-ml-8 md:-ml-4 rounded-3xl bg-primary-900'>
         <div className='rounded-tl rounded-tr relative justify-between items-center flex border-b border-primary-400 py-2 px-4 text-sm text-gray-300'>
           <div className='items-center flex'>
             <span>
-              <Link href={`/player/${actor.id}`} className='font-semibold'>
-                {actor.name}
-              </Link> commented&nbsp;
-              <Link href={`#comment-${id}`}>
-
-                <span>{fromNow(created)}</span>
-
-              </Link>
+              {t.rich('pages.appeals.commentedAt', {
+                actorName: actor.name,
+                relative: fromNow(created),
+                actor: (chunks) => <Link href={`/player/${actor.id}`} className='font-semibold'>{chunks}</Link>,
+                time: (chunks) => <Link href={`#comment-${id}`}><span>{chunks}</span></Link>
+              })}
             </span>
           </div>
           <div className='items-center flex'>
-            {acl?.delete && <a className='cursor-pointer' onClick={showConfirmDelete}>Delete</a>}
+            {acl?.delete && <a className='cursor-pointer' onClick={showConfirmDelete}>{t('common.delete')}</a>}
           </div>
         </div>
         <div className='rounded-bl rounded-br relative p-4 top-0 bottom-0'>

--- a/components/appeals/PlayerAppealCommentPunishmentUpdate.js
+++ b/components/appeals/PlayerAppealCommentPunishmentUpdate.js
@@ -1,30 +1,70 @@
 import Link from 'next/link'
 import { GoIssueClosed, GoPencil, GoEyeClosed, GoEye, GoClock } from 'react-icons/go'
 import { format, fromUnixTime } from 'date-fns'
+import { useLocale, useTranslations } from 'next-intl'
 import Avatar from '../Avatar'
 import { fromNow } from '../../utils'
+import { LOCALE_CONFIG, DEFAULT_LOCALE } from '../../utils/locale'
+import { useDateFnsLocale } from '../../utils/format-distance'
 
 export default function PlayerAppealCommentPunishmentUpdate ({ id, actor, created, state, oldReason, newReason, oldExpires, newExpires, oldSoft, newSoft }) {
+  const t = useTranslations('pages.appeals.updates')
+  const locale = useLocale()
+  const dateFnsLocale = useDateFnsLocale()
+  const dateFormat = `${LOCALE_CONFIG[locale]?.dateFormat || LOCALE_CONFIG[DEFAULT_LOCALE].dateFormat} HH:mm:ss`
+
+  const expiryFormat = (expiry) => {
+    if (expiry === 0) return t('permanent')
+
+    try {
+      return format(fromUnixTime(expiry), dateFormat, dateFnsLocale ? { locale: dateFnsLocale } : undefined)
+    } catch {
+      return format(fromUnixTime(expiry), dateFormat)
+    }
+  }
+
+  const softLabel = (soft) => soft ? t('shadow') : t('notShadow')
+
+  const richTags = {
+    actor: (chunks) => <Link href={`/player/${actor.id}`}>{chunks}</Link>,
+    old: (chunks) => <span className='font-bold line-through'>{chunks}</span>,
+    new: (chunks) => <span className='font-bold'>{chunks}</span>
+  }
+
   const messages = []
-  const expiryFormat = (expiry) => expiry === 0 ? 'permanent' : format(fromUnixTime(expiry), 'dd MMM yyyy HH:mm:ss')
 
   if (oldReason && newReason) {
     messages.push({
-      message: <>changed the reason from <span className='font-bold line-through'>{oldReason}</span> to <span className='font-bold'>{newReason}</span></>
+      message: t.rich('reasonChanged', {
+        ...richTags,
+        actorName: actor.name,
+        oldReason,
+        newReason
+      })
     })
   }
 
   if (typeof oldExpires === 'number' && typeof newExpires === 'number') {
     messages.push({
       icon: <GoClock className='w-6 h-6 inline-block' />,
-      message: <>modified the expiration from <span className='font-bold line-through'>{expiryFormat(oldExpires)}</span> to <span className='font-bold'>{expiryFormat(newExpires)}</span></>
+      message: t.rich('expirationChanged', {
+        ...richTags,
+        actorName: actor.name,
+        oldExpires: expiryFormat(oldExpires),
+        newExpires: expiryFormat(newExpires)
+      })
     })
   }
 
   if (typeof oldSoft === 'boolean' && typeof newSoft === 'boolean') {
     messages.push({
       icon: newSoft ? <GoEyeClosed className='w-6 h-6 inline-block' /> : <GoEye className='w-6 h-6 inline-block' />,
-      message: <>set <span className='font-bold line-through'>{oldSoft ? 'shadow' : 'not shadow'}</span> to <span className='font-bold'>{newSoft ? 'shadow' : 'not shadow'}</span></>
+      message: t.rich('softChanged', {
+        ...richTags,
+        actorName: actor.name,
+        oldSoft: softLabel(oldSoft),
+        newSoft: softLabel(newSoft)
+      })
     })
   }
 
@@ -44,13 +84,7 @@ export default function PlayerAppealCommentPunishmentUpdate ({ id, actor, create
               <Avatar uuid={actor.id} width={20} height={20} />
 
             </Link>
-            <span className='pl-1 text-sm text-gray-300'>
-              <Link href={`/player/${actor.id}`} className=''>
-
-                {actor.name}
-
-              </Link> {message}
-            </span>
+            <span className='pl-1 text-sm text-gray-300'>{message}</span>
           </div>
         ))}
       <div className='ml-4 pt-3 pb-3 pl-4 relative' id={`comment-${id}`}>
@@ -66,11 +100,12 @@ export default function PlayerAppealCommentPunishmentUpdate ({ id, actor, create
 
         </Link>
         <span className='pl-1 text-sm text-gray-300'>
-          <Link href={`/player/${actor.id}`} className=''>
-
-            {actor.name}
-
-          </Link> marked this appeal as {state.name.toLowerCase()} {fromNow(created)}
+          {t.rich('stateMarked', {
+            ...richTags,
+            actorName: actor.name,
+            state: state.name.toLowerCase(),
+            time: fromNow(created)
+          })}
         </span>
       </div>
     </>

--- a/components/appeals/PlayerAppealSidebar.js
+++ b/components/appeals/PlayerAppealSidebar.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import { useMatchMutate } from '../../utils'
 import SidebarDocuments from '../SidebarDocuments'
 import PlayerAppealActions from './PlayerAppealActions'
@@ -19,6 +20,7 @@ const SidebarItem = ({ title, children }) => (
 )
 
 export default function PlayerAppealSidebar ({ data, canUpdateState, canAssign, stateOptions, mutate, user }) {
+  const t = useTranslations('pages.appeals.sidebar')
   const matchMutate = useMatchMutate()
   const mutateCommentInsert = (comment) => ({ data }, mutate) => {
     const records = data.listPlayerAppealComments.records.slice()
@@ -30,7 +32,7 @@ export default function PlayerAppealSidebar ({ data, canUpdateState, canAssign, 
 
   return (
     <ul role='list' className='divide-y divide-primary-900'>
-      <SidebarItem title='State'>
+      <SidebarItem title={t('state')}>
         <div data-cy='appeal-state'>
           {canUpdateState
             ? (
@@ -46,7 +48,7 @@ export default function PlayerAppealSidebar ({ data, canUpdateState, canAssign, 
             : (<p className='text-sm' data-cy='appeal-state-display'>{appeal?.state?.name}</p>)}
         </div>
       </SidebarItem>
-      <SidebarItem title='Assignee'>
+      <SidebarItem title={t('assignee')}>
         <div data-cy='appeal-assignee'>
           {canAssign
             ? (
@@ -58,11 +60,11 @@ export default function PlayerAppealSidebar ({ data, canUpdateState, canAssign, 
                   matchMutate('listPlayerAppealComments', mutateCommentInsert(comment), { id: appeal.id })
                 }}
               />)
-            : (<p className='text-sm' data-cy='appeal-assignee-display'>{appeal?.assignee?.name || 'Unassigned'}</p>)}
+            : (<p className='text-sm' data-cy='appeal-assignee-display'>{appeal?.assignee?.name || t('unassigned')}</p>)}
         </div>
       </SidebarItem>
       {!!user &&
-        <SidebarItem title='Notifications'>
+        <SidebarItem title={t('notifications')}>
           <PlayerAppealNotifications
             appeal={appeal}
             onChange={({ appealSubscriptionState }) => {
@@ -71,11 +73,11 @@ export default function PlayerAppealSidebar ({ data, canUpdateState, canAssign, 
           />
         </SidebarItem>}
       {appeal.documents?.length > 0 &&
-        <SidebarItem title='Documents'>
+        <SidebarItem title={t('documents')}>
           <SidebarDocuments documents={appeal.documents} />
         </SidebarItem>}
       {!!user && appeal.state.id < 3 &&
-        <SidebarItem title='Actions'>
+        <SidebarItem title={t('actions')}>
           <PlayerAppealActions
             appeal={appeal}
             server={appeal.server}

--- a/components/appeals/actions/PlayerAppealActionDelete.js
+++ b/components/appeals/actions/PlayerAppealActionDelete.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { BsTrash } from 'react-icons/bs'
 import Button from '../../Button'
 import ErrorMessages from '../../ErrorMessages'
@@ -6,6 +7,7 @@ import Modal from '../../Modal'
 import { useMutateApi } from '../../../utils'
 
 export default function PlayerAppealActionDelete ({ appeal, title, type, query, onDeleted }) {
+  const t = useTranslations()
   const [open, setOpen] = useState(false)
   const { load, data, loading, errors } = useMutateApi({ query })
 
@@ -30,7 +32,7 @@ export default function PlayerAppealActionDelete ({ appeal, title, type, query, 
   return (
     <>
       <Modal
-        title={`Remove ${type}`}
+        title={t(`pages.appeals.removeTitle.${type}`)}
         confirmButton={title}
         open={open}
         onConfirm={handleConfirmDelete}
@@ -38,8 +40,8 @@ export default function PlayerAppealActionDelete ({ appeal, title, type, query, 
         loading={loading}
       >
         <ErrorMessages errors={errors} />
-        <p className='pb-1'>Are you sure you want to remove this {type}?</p>
-        <p className='pb-1'>This action cannot be undone</p>
+        <p className='pb-1'>{t(`pages.appeals.removeConfirm.${type}`)}</p>
+        <p className='pb-1'>{t('pages.punishment.actionUndoable')}</p>
       </Modal>
       <Button onClick={showConfirmDelete} className='bg-red-800'>
         <BsTrash className='text-xl mr-2' /> {title}

--- a/components/appeals/actions/PlayerAppealActionUpdate.js
+++ b/components/appeals/actions/PlayerAppealActionUpdate.js
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { FaPencilAlt } from 'react-icons/fa'
 import Button from '../../Button'
 import Modal from '../../Modal'
@@ -7,6 +8,7 @@ import PlayerMuteForm from '../../PlayerMuteForm'
 import PlayerWarnForm from '../../PlayerWarnForm'
 
 export default function PlayerAppealActionUpdate ({ appeal, title, type, query, onUpdated }) {
+  const t = useTranslations('pages.appeals.editTitle')
   const [open, setOpen] = useState(false)
   const submitRef = useRef(null)
 
@@ -23,7 +25,7 @@ export default function PlayerAppealActionUpdate ({ appeal, title, type, query, 
   return (
     <>
       <Modal
-        title={`Edit ${type}`}
+        title={t(type)}
         confirmButton={title}
         open={open}
         onConfirm={handleConfirm}

--- a/components/dashboard/ActivePunishments.js
+++ b/components/dashboard/ActivePunishments.js
@@ -1,5 +1,6 @@
 import { format, fromUnixTime } from 'date-fns'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import Loader from '../Loader'
 import Avatar from '../Avatar'
 import Badge from '../Badge'
@@ -39,6 +40,7 @@ query playerBans($id: UUID!) {
 }`
 
 const PunishmentRow = ({ row, dateFormat }) => {
+  const t = useTranslations()
   return (
     <Table.Row>
       <Table.Cell>{row.typeLabel}</Table.Cell>
@@ -60,11 +62,11 @@ const PunishmentRow = ({ row, dateFormat }) => {
         </Link>
       </Table.Cell>
       <Table.Cell>{format(fromUnixTime(row.created), dateFormat)}</Table.Cell>
-      <Table.Cell>{row.expires === 0 ? <Badge className='bg-red-500 sm:mx-auto'>Permanent</Badge> : fromNow(row.expires)}</Table.Cell>
+      <Table.Cell>{row.expires === 0 ? <Badge className='bg-red-500 sm:mx-auto'>{t('common.permanent')}</Badge> : fromNow(row.expires)}</Table.Cell>
       <Table.Cell>
         <Link href={`/appeal/punishment/${row.server.id}/${row.type}/${row.id}`} passHref>
           <Badge className='bg-blue-600 hover:bg-blue-900 mt-4'>
-            Appeal
+            {t('pages.punishment.appeal')}
           </Badge>
         </Link>
       </Table.Cell>
@@ -73,6 +75,7 @@ const PunishmentRow = ({ row, dateFormat }) => {
 }
 
 export default function ActivePunishments ({ id }) {
+  const t = useTranslations()
   const { loading, data, errors } = useApi({ query, variables: { id } })
 
   if (loading) return <Loader />
@@ -82,11 +85,11 @@ export default function ActivePunishments ({ id }) {
   let rows = []
 
   if (data?.playerBans?.length) {
-    rows = rows.concat(data.playerBans.map(data => ({ type: 'ban', typeLabel: <Badge className='bg-red-500 sm:mx-auto'>Ban</Badge>, ...data })))
+    rows = rows.concat(data.playerBans.map(data => ({ type: 'ban', typeLabel: <Badge className='bg-red-500 sm:mx-auto'>{t('pages.player.actions.ban')}</Badge>, ...data })))
   }
 
   if (data?.playerMutes?.length) {
-    rows = rows.concat(data.playerMutes.map(data => ({ type: 'mute', typeLabel: <Badge className='bg-indigo-500 sm:mx-auto'>Mute</Badge>, ...data })))
+    rows = rows.concat(data.playerMutes.map(data => ({ type: 'mute', typeLabel: <Badge className='bg-indigo-500 sm:mx-auto'>{t('pages.player.actions.mute')}</Badge>, ...data })))
   }
 
   rows.sort((a, b) => b.created - a.created)
@@ -95,11 +98,11 @@ export default function ActivePunishments ({ id }) {
     <Table>
       <Table.Header>
         <Table.Row>
-          <Table.HeaderCell>Type</Table.HeaderCell>
-          <Table.HeaderCell>Reason</Table.HeaderCell>
-          <Table.HeaderCell>By</Table.HeaderCell>
-          <Table.HeaderCell>At</Table.HeaderCell>
-          <Table.HeaderCell>Length</Table.HeaderCell>
+          <Table.HeaderCell>{t('tables.type')}</Table.HeaderCell>
+          <Table.HeaderCell>{t('tables.reason')}</Table.HeaderCell>
+          <Table.HeaderCell>{t('tables.by')}</Table.HeaderCell>
+          <Table.HeaderCell>{t('tables.at')}</Table.HeaderCell>
+          <Table.HeaderCell>{t('tables.length')}</Table.HeaderCell>
           <Table.HeaderCell />
         </Table.Row>
       </Table.Header>

--- a/components/dashboard/PlayerAppeals.js
+++ b/components/dashboard/PlayerAppeals.js
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { format, fromUnixTime } from 'date-fns'
+import { useTranslations } from 'next-intl'
 import Badge from '../Badge'
 import Link from 'next/link'
 import Loader from '../Loader'
@@ -92,6 +93,7 @@ const AppealRow = ({ row, dateFormat, showActor }) => {
 }
 
 export default function PlayerAppeals ({ id, title, showActor }) {
+  const t = useTranslations()
   const { hasPermission } = useUser()
   const [tableState, setTableState] = useState({ id, serverId: null, activePage: 1, limit: 10, offset: 0, assigned: null, state: null })
   const { loading, data } = useApi({ query, variables: tableState })
@@ -113,30 +115,30 @@ export default function PlayerAppeals ({ id, title, showActor }) {
           <p className='mr-6' data-cy='dashboard-widget-title'>{title}</p>
           {(hasPermission('player.appeals', 'view.any') || hasPermission('player.appeals', 'view.assigned')) &&
             <div className='ml-3 text-sm'>
-              <Link href='/dashboard/appeals' data-cy='dashboard-widget-view-all'>View All</Link>
+              <Link href='/dashboard/appeals' data-cy='dashboard-widget-view-all'>{t('pages.dashboard.viewAll')}</Link>
             </div>}
         </div>
       </h1>
       <Table>
         <Table.Header>
           <Table.Row>
-            <Table.HeaderCell>ID</Table.HeaderCell>
+            <Table.HeaderCell>{t('tables.id')}</Table.HeaderCell>
             {showActor &&
               <Table.HeaderCell>
                 <PlayerSelector
                   multiple={false}
                   onChange={(id) => setTableState({ ...tableState, id })}
-                  placeholder='By'
+                  placeholder={t('tables.by')}
                   clearable
                 />
               </Table.HeaderCell>}
-            <Table.HeaderCell>Type</Table.HeaderCell>
-            <Table.HeaderCell>At</Table.HeaderCell>
+            <Table.HeaderCell>{t('tables.type')}</Table.HeaderCell>
+            <Table.HeaderCell>{t('tables.at')}</Table.HeaderCell>
             <Table.HeaderCell>
               <Select
                 options={data?.appealStates?.map(state => ({ value: state.id, label: state.name }))}
                 onChange={(value) => setTableState({ ...tableState, state: value?.value })}
-                placeholder='State'
+                placeholder={t('tables.state')}
                 isClearable
               />
             </Table.HeaderCell>
@@ -144,11 +146,11 @@ export default function PlayerAppeals ({ id, title, showActor }) {
               <PlayerSelector
                 multiple={false}
                 onChange={(id) => setTableState({ ...tableState, assigned: id })}
-                placeholder='Assigned'
+                placeholder={t('tables.assigned')}
                 clearable
               />
             </Table.HeaderCell>
-            <Table.HeaderCell>Last Updated</Table.HeaderCell>
+            <Table.HeaderCell>{t('tables.lastUpdated')}</Table.HeaderCell>
           </Table.Row>
         </Table.Header>
         <Table.Body>

--- a/components/dashboard/PlayerReports.js
+++ b/components/dashboard/PlayerReports.js
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { format, fromUnixTime } from 'date-fns'
+import { useTranslations } from 'next-intl'
 import Badge from '../Badge'
 import Link from 'next/link'
 import Loader from '../Loader'
@@ -84,6 +85,7 @@ const ReportRow = ({ serverId, row, dateFormat }) => {
 }
 
 export default function PlayerReports ({ id, title }) {
+  const t = useTranslations()
   const { hasPermission } = useUser()
   const [tableState, setTableState] = useState({ id, serverId: null, activePage: 1, limit: 10, offset: 0, actor: null, assigned: null, state: null })
   const { loading, data } = useApi({ query: !tableState.serverId ? null : query, variables: tableState })
@@ -110,19 +112,19 @@ export default function PlayerReports ({ id, title }) {
           </div>
           {(hasPermission('player.reports', 'view.any') || hasPermission('player.reports', 'view.assigned')) &&
             <div className='ml-3 text-sm'>
-              <Link href='/dashboard/reports' data-cy='dashboard-widget-view-all'>View All</Link>
+              <Link href='/dashboard/reports' data-cy='dashboard-widget-view-all'>{t('pages.dashboard.viewAll')}</Link>
             </div>}
         </div>
       </h1>
       <Table>
         <Table.Header>
           <Table.Row>
-            <Table.HeaderCell>ID</Table.HeaderCell>
-            <Table.HeaderCell>Player</Table.HeaderCell>
-            <Table.HeaderCell>At</Table.HeaderCell>
-            <Table.HeaderCell>State</Table.HeaderCell>
-            <Table.HeaderCell>Assigned</Table.HeaderCell>
-            <Table.HeaderCell>Last Updated</Table.HeaderCell>
+            <Table.HeaderCell>{t('tables.id')}</Table.HeaderCell>
+            <Table.HeaderCell>{t('tables.player')}</Table.HeaderCell>
+            <Table.HeaderCell>{t('tables.at')}</Table.HeaderCell>
+            <Table.HeaderCell>{t('tables.state')}</Table.HeaderCell>
+            <Table.HeaderCell>{t('tables.assigned')}</Table.HeaderCell>
+            <Table.HeaderCell>{t('tables.lastUpdated')}</Table.HeaderCell>
           </Table.Row>
         </Table.Header>
         <Table.Body>

--- a/components/home/AccountPanel.js
+++ b/components/home/AccountPanel.js
@@ -1,5 +1,6 @@
 import { mutate } from 'swr'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import PlayerLoginPasswordForm from '../PlayerLoginPasswordForm'
 import Avatar from '../Avatar'
 import Button from '../Button'
@@ -8,6 +9,7 @@ import PageHeader from '../PageHeader'
 import Panel from '../Panel'
 
 const AccountPanel = () => {
+  const t = useTranslations()
   const { user } = useUser()
   const handleLogin = () => {
     mutate('/api/user')
@@ -15,14 +17,17 @@ const AccountPanel = () => {
 
   return (
     <Panel>
-      <PageHeader title={user ? user.name : 'Sign In'} subTitle={user ? 'My Account' : 'Already have an account?'} />
+      <PageHeader
+        title={user ? user.name : t('pages.home.account.signInTitle')}
+        subTitle={user ? t('pages.home.account.myAccountSubtitle') : t('pages.home.account.signInSubtitle')}
+      />
       <div className='flex items-center'>
         {user
           ? (
             <div className='flex flex-col items-center w-full gap-2'>
               <Avatar type='body' height='148' width='91' uuid={user.id} />
               <Link href='/dashboard' passHref>
-                <Button>My Dashboard</Button>
+                <Button>{t('pages.home.account.dashboardCta')}</Button>
               </Link>
             </div>
             )

--- a/components/home/AppealPanel.js
+++ b/components/home/AppealPanel.js
@@ -1,22 +1,24 @@
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import Button from '../Button'
 import PageHeader from '../PageHeader'
 import Panel from '../Panel'
 import { useUser } from '../../utils'
 
 const AppealPanel = () => {
+  const t = useTranslations()
   const { user } = useUser()
 
   return (
     <Panel>
-      <PageHeader title='Appeal' subTitle='Help I&apos;ve been banned' />
+      <PageHeader title={t('pages.home.appeal.title')} subTitle={t('pages.home.appeal.subtitle')} />
       <p className='flex mb-6'>
-        If you believe your account has been wrongfully punished, create an appeal justifying why including any relevant evidence.
+        {t('pages.home.appeal.intro')}
       </p>
-      <p className='mb-3'>There is no guarantee your appeal will be successful.</p>
+      <p className='mb-3'>{t('pages.home.appeal.warning')}</p>
       <Link href={user ? '/appeal/punishment' : '/appeal'} passHref className='mt-auto'>
         <Button>
-          Create Appeal
+          {t('pages.home.appeal.cta')}
         </Button>
       </Link>
     </Panel>

--- a/components/home/SearchPanel.js
+++ b/components/home/SearchPanel.js
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import { useApi } from '../../utils'
 import PlayerSelector from '../admin/PlayerSelector'
 import Loader from '../Loader'
@@ -8,6 +9,7 @@ import PageHeader from '../PageHeader'
 import Panel from '../Panel'
 
 const SearchPanel = () => {
+  const t = useTranslations()
   const router = useRouter()
   const query = `query searchPlayers($name: String!, $limit: Int!) {
     searchPlayers(name: $name, limit: $limit) {
@@ -20,9 +22,9 @@ const SearchPanel = () => {
 
   return (
     <Panel>
-      <PageHeader title='Search' subTitle='Find a player' />
+      <PageHeader title={t('pages.home.search.title')} subTitle={t('pages.home.search.subtitle')} />
       <p className='flex items-center mb-6'>
-        Check the full punishment history of a player, including current bans, mutes and more!
+        {t('pages.home.search.intro')}
       </p>
       <div className='flex flex-col w-full max-w-md px-4 sm:px-6 md:px-8 lg:px-10 mx-auto mt-auto'>
         <div className='grid grid-flow-col grid-cols-6 grid-rows-1 gap-4 mb-3'>
@@ -44,7 +46,7 @@ const SearchPanel = () => {
         className='md:mt-auto mt-3'
         multiple={false}
         onChange={(id) => id ? router.push(`/player/${id}`) : undefined}
-        placeholder='Enter player name'
+        placeholder={t('pages.home.search.placeholder')}
       />
     </Panel>
   )

--- a/components/home/StatisticsPanel.js
+++ b/components/home/StatisticsPanel.js
@@ -2,10 +2,12 @@ import { FaBan } from 'react-icons/fa'
 import { BsMicMute } from 'react-icons/bs'
 import { FiUsers } from 'react-icons/fi'
 import { MdOutlineGavel } from 'react-icons/md'
+import { useTranslations } from 'next-intl'
 import Loader from '../Loader'
 import { numberFormatter, useApi } from '../../utils'
 
 const StatisticsPanel = () => {
+  const t = useTranslations()
   const { data, loading } = useApi({
     query: `query statistics {
     statistics {
@@ -26,7 +28,7 @@ const StatisticsPanel = () => {
             <>
               <FaBan className='text-red-800 w-12 h-12 mb-3 inline-block' />
               <h2 className='title-font font-medium text-3xl'>{numberFormatter(data?.statistics?.totalActiveBans || 0)}</h2>
-              <p className='leading-relaxed text-gray-300'>Ban{data?.statistics?.totalActiveBans !== 1 && 's'}</p>
+              <p className='leading-relaxed text-gray-300'>{t('stats.bans', { count: data?.statistics?.totalActiveBans || 0 })}</p>
             </>}
         </div>
       </div>
@@ -37,7 +39,7 @@ const StatisticsPanel = () => {
             <>
               <BsMicMute className='text-indigo-800 w-12 h-12 mb-3 inline-block' />
               <h2 className='title-font font-medium text-3xl'>{numberFormatter(data?.statistics?.totalActiveMutes || 0)}</h2>
-              <p className='leading-relaxed text-gray-300'>Mute{data?.statistics?.totalActiveMutes !== 1 && 's'}</p>
+              <p className='leading-relaxed text-gray-300'>{t('stats.mutes', { count: data?.statistics?.totalActiveMutes || 0 })}</p>
             </>}
         </div>
       </div>
@@ -48,7 +50,7 @@ const StatisticsPanel = () => {
             <>
               <FiUsers className='text-pink-800 w-12 h-12 mb-3 inline-block' />
               <h2 className='title-font font-medium text-3xl'>{numberFormatter(data?.statistics?.totalPlayers || 0)}</h2>
-              <p className='leading-relaxed text-gray-300'>Player{data?.statistics?.totalPlayers !== 1 && 's'}</p>
+              <p className='leading-relaxed text-gray-300'>{t('stats.players', { count: data?.statistics?.totalPlayers || 0 })}</p>
             </>}
         </div>
       </div>
@@ -59,7 +61,7 @@ const StatisticsPanel = () => {
             <>
               <MdOutlineGavel className='text-yellow-800 w-12 h-12 mb-3 inline-block' />
               <h2 className='title-font font-medium text-3xl'>{numberFormatter(data?.statistics?.totalAppeals || 0)}</h2>
-              <p className='leading-relaxed text-gray-300'>Appeal{data?.statistics?.totalAppeals !== 1 && 's'}</p>
+              <p className='leading-relaxed text-gray-300'>{t('stats.appeals', { count: data?.statistics?.totalAppeals || 0 })}</p>
             </>}
         </div>
       </div>

--- a/components/notifications/NotificationList.js
+++ b/components/notifications/NotificationList.js
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { useApi } from '../../utils'
 import Loader from '../Loader'
 import NotificationReportComment from './NotificationReportComment'
@@ -11,6 +12,7 @@ import Pagination from '../Pagination'
 import NotificationAppealCreated from './NotificationAppealCreated'
 
 const NotificationList = () => {
+  const t = useTranslations()
   const [tableState, setTableState] = useState({ activePage: 1, limit: 25, offset: 0 })
   const { loading, data } = useApi({
     query: `query listNotifications($limit: Int, $offset: Int) {
@@ -82,7 +84,7 @@ const NotificationList = () => {
     <>
       <div className='grid grid-cols-1 bg-primary-900 rounded-t-3xl rounded-b-3xl py-4 divide-y-2 divide-primary-400' data-cy='notification-list'>
         {!data?.listNotifications?.total
-          ? <p className='text-center' data-cy='notification-list-empty'>Nothing to see here yet</p>
+          ? <p className='text-center' data-cy='notification-list-empty'>{t('pages.notifications.empty')}</p>
           : data?.listNotifications?.records?.map(record => {
             switch (record.type) {
               case 'reportComment':

--- a/components/notifications/PushNotificationButton.js
+++ b/components/notifications/PushNotificationButton.js
@@ -1,10 +1,12 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import Button from '../Button'
 import Modal from '../Modal'
 
 export default function PushNotificationButton () {
+  const t = useTranslations('widgets.pushNotifications')
   const [open, setOpen] = useState(false)
   const [subscription, setSubscription] = useState(null)
   const [notificationPermission, setNotificationPermission] = useState(Notification.permission)
@@ -87,68 +89,68 @@ export default function PushNotificationButton () {
     <>
       {(notificationPermission === 'default' || (notificationPermission === 'granted' && !subscription)) &&
         <Button className='bg-primary-900 text-gray-400 font-normal w-auto' onClick={onClickRegisterPushNotification}>
-          Enable push notifications
+          {t('enable')}
         </Button>}
       {notificationPermission === 'granted' && subscription &&
         <Button className='bg-primary-900 text-gray-400 font-normal w-auto' onClick={onClickUnregisterPushNotification}>
-          Disable push notifications
+          {t('disable')}
         </Button>}
       {notificationPermission === 'denied' &&
         <Button className='bg-primary-900 text-gray-400 font-normal w-auto' onClick={() => setOpen(true)}>
-          Enable push notifications
+          {t('enable')}
         </Button>}
-      <Modal title='Enable Push Notifications' open={open} onCancel={() => setOpen(false)} cancelButton='Ok'>
+      <Modal title={t('blockedTitle')} open={open} onCancel={() => setOpen(false)} cancelButton={t('ok')}>
         <div className='flex flex-col gap-4'>
-          <p>Your browser is blocking notifications from this site</p>
-          <p>Follow these steps to enable:</p>
+          <p>{t('blockedIntro')}</p>
+          <p>{t('blockedSteps')}</p>
 
           <div>
-            <h3 className='font-semibold'>Chrome</h3>
+            <h3 className='font-semibold'>{t('chrome')}</h3>
             <ol className='list-decimal pl-4'>
-              <li>Navigate to: <pre className='inline'>chrome://settings/content</pre></li>
-              <li>Scroll down and click on the Notifications bar</li>
-              <li>Find the URL of this site select allow</li>
+              <li>{t.rich('chromeStep1', { path: (chunks) => <pre className='inline'>{chunks}</pre> })}</li>
+              <li>{t('chromeStep2')}</li>
+              <li>{t('chromeStep3')}</li>
             </ol>
           </div>
 
           <div>
-            <h3 className='font-semibold'>Chrome for Android</h3>
+            <h3 className='font-semibold'>{t('chromeAndroid')}</h3>
             <ol className='list-decimal pl-4'>
-              <li>Select the vertical elipses icon in the top-right corner of the screen</li>
-              <li>Select the “Settings” option from the dropdown menu</li>
-              <li>Select the “Site settings” option</li>
-              <li>Select the “Notifications” option</li>
-              <li>Here you can select this website and enable notifications</li>
+              <li>{t('chromeAndroidStep1')}</li>
+              <li>{t('chromeAndroidStep2')}</li>
+              <li>{t('chromeAndroidStep3')}</li>
+              <li>{t('chromeAndroidStep4')}</li>
+              <li>{t('chromeAndroidStep5')}</li>
             </ol>
           </div>
 
           <div>
-            <h3 className='font-semibold'>Firefox</h3>
+            <h3 className='font-semibold'>{t('firefox')}</h3>
             <ol className='list-decimal pl-4'>
-              <li>Navigate to: <pre className='inline'>about:preferences#privacy</pre></li>
-              <li>Scroll down to the Permissions section</li>
-              <li>Click the Settings button next to Notifications</li>
-              <li>Find the URL of this site and select Allow</li>
+              <li>{t.rich('firefoxStep1', { path: (chunks) => <pre className='inline'>{chunks}</pre> })}</li>
+              <li>{t('firefoxStep2')}</li>
+              <li>{t('firefoxStep3')}</li>
+              <li>{t('firefoxStep4')}</li>
             </ol>
           </div>
 
           <div>
-            <h3 className='font-semibold'>Microsoft Edge</h3>
+            <h3 className='font-semibold'>{t('edge')}</h3>
             <ol className='list-decimal pl-4'>
-              <li>Select the “...” button in the top-right corner of the browser window</li>
-              <li>Select the “Settings” option from the dropdown menu</li>
-              <li>Select the “Cookies and site permissions” option</li>
-              <li>Select the “Notifications” option</li>
-              <li>Remove this site from the “Block“ section</li>
+              <li>{t('edgeStep1')}</li>
+              <li>{t('edgeStep2')}</li>
+              <li>{t('edgeStep3')}</li>
+              <li>{t('edgeStep4')}</li>
+              <li>{t('edgeStep5')}</li>
             </ol>
           </div>
 
           <div>
-            <h3 className='font-semibold'>Safari</h3>
+            <h3 className='font-semibold'>{t('safari')}</h3>
             <ol className='list-decimal pl-4'>
-              <li>Select “Safari” in the action bar at the top of the screen and select “Preferences”</li>
-              <li>Click on the “Websites” tab and then select “Notifications” in the menu on the left-side of the preferences window</li>
-              <li>Find this site and enable notifications</li>
+              <li>{t('safariStep1')}</li>
+              <li>{t('safariStep2')}</li>
+              <li>{t('safariStep3')}</li>
             </ol>
           </div>
         </div>

--- a/components/player/ActivePlayerBans.js
+++ b/components/player/ActivePlayerBans.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import Loader from '../Loader'
 import PlayerHeader from './PlayerHeader'
 import PlayerPunishment from './PlayerPunishment'
@@ -28,6 +29,7 @@ query playerBans($id: UUID!) {
 }`
 
 export default function ActivePlayerBans ({ id }) {
+  const t = useTranslations()
   const { loading, data, mutate, errors } = useApi({ query, variables: { id } })
 
   if (loading) return <Loader />
@@ -49,7 +51,7 @@ export default function ActivePlayerBans ({ id }) {
 
   return (
     <div>
-      <PlayerHeader title={`Active Bans (${data.playerBans.length})`} />
+      <PlayerHeader title={t('pages.player.activeBans', { total: data.playerBans.length })} />
       <div className='flex flex-col gap-6'>
         {rows}
       </div>

--- a/components/player/ActivePlayerMutes.js
+++ b/components/player/ActivePlayerMutes.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import Loader from '../Loader'
 import PlayerPunishment from './PlayerPunishment'
 import { useApi } from '../../utils'
@@ -28,6 +29,7 @@ query playerMutes($id: UUID!) {
 }`
 
 export default function ActivePlayerMutes ({ id }) {
+  const t = useTranslations()
   const { loading, data, errors, mutate } = useApi({ query, variables: { id } })
 
   if (loading) return <Loader />
@@ -49,7 +51,7 @@ export default function ActivePlayerMutes ({ id }) {
 
   return (
     <div>
-      <PlayerHeader title={`Active Mutes (${data.playerMutes.length})`} />
+      <PlayerHeader title={t('pages.player.activeMutes', { total: data.playerMutes.length })} />
       <div className='flex flex-col gap-6'>
         {rows}
       </div>

--- a/components/player/PastPlayerPunishment.js
+++ b/components/player/PastPlayerPunishment.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import { BsTrash } from 'react-icons/bs'
 import Badge from '../Badge'
 import PermanentBadge from './PermanentBadge'
@@ -47,6 +48,7 @@ const metaMap = {
 }
 
 export default function PastPlayerPunishment ({ punishment, serverId, type, onDeleted }) {
+  const t = useTranslations()
   const meta = metaMap[type]
   const [open, setOpen] = useState(false)
 
@@ -120,22 +122,22 @@ export default function PastPlayerPunishment ({ punishment, serverId, type, onDe
           </div>
           {punishment.createdReason
             ? <div className='break-words whitespace-normal mt-2'>{punishment.createdReason}</div>
-            : <div className='mt-2 text-gray-400'>Deletion reason unknown</div>}
+            : <div className='mt-2 text-gray-400'>{t('pages.punishment.deletionReasonUnknown')}</div>}
         </div>
       </div>
       {punishment.acl.delete &&
         <>
           <Modal
-            title={`Delete ${type}`}
-            confirmButton='Delete'
+            title={t(`pages.punishment.deleteTitle.${type}`)}
+            confirmButton={t('common.delete')}
             open={open}
             onConfirm={handleConfirmDelete}
             onCancel={handleDeleteCancel}
             loading={loading}
           >
             <ErrorMessages errors={errors} />
-            <p className='pb-1'>Are you sure you want to delete this {type}?</p>
-            <p className='pb-1'>This action cannot be undone</p>
+            <p className='pb-1'>{t(`pages.punishment.deleteConfirm.${type}`)}</p>
+            <p className='pb-1'>{t('pages.punishment.actionUndoable')}</p>
           </Modal>
           <div className='hidden lg:flex justify-end'>
             <Button className='mt-4 bg-red-800 w-auto' onClick={showConfirmDelete}>

--- a/components/player/PermanentBadge.js
+++ b/components/player/PermanentBadge.js
@@ -1,8 +1,11 @@
 import { FaInfinity } from 'react-icons/fa'
+import { useTranslations } from 'next-intl'
 import Badge from '../Badge'
 
 export default function PermanentBadge ({ className = '' }) {
+  const t = useTranslations('common')
+
   return (
-    <Badge className={`bg-red-800 py-0 px-1 flex ${className}`} title='Permanent'><FaInfinity /></Badge>
+    <Badge className={`bg-red-800 py-0 px-1 flex ${className}`} title={t('permanent')}><FaInfinity /></Badge>
   )
 }

--- a/components/player/PlayerActions.js
+++ b/components/player/PlayerActions.js
@@ -1,11 +1,13 @@
 import { AiOutlineWarning } from 'react-icons/ai'
 import { BsMicMute } from 'react-icons/bs'
 import { FaBan, FaStickyNote } from 'react-icons/fa'
+import { useTranslations } from 'next-intl'
 import { useUser } from '../../utils'
 import Link from 'next/link'
 import Button from '../Button'
 
 export default function PlayerActions ({ id }) {
+  const t = useTranslations()
   const { hasServerPermission } = useUser()
   const canCreateBan = hasServerPermission('player.bans', 'create', null, true)
   const canCreateMute = hasServerPermission('player.mutes', 'create', null, true)
@@ -19,25 +21,25 @@ export default function PlayerActions ({ id }) {
       <div>
         {canCreateBan &&
           <Link href={`/player/${id}/ban`} passHref>
-            <Button data-cy='action-ban' className='btn-outline'><FaBan className='text-red-800 mr-1' /> Ban</Button>
+            <Button data-cy='action-ban' className='btn-outline'><FaBan className='text-red-800 mr-1' /> {t('pages.player.actions.ban')}</Button>
           </Link>}
       </div>
       <div>
         {canCreateMute &&
           <Link href={`/player/${id}/mute`} passHref>
-            <Button data-cy='action-mute' className='btn-outline'><BsMicMute className='text-indigo-800 mr-1' /> Mute</Button>
+            <Button data-cy='action-mute' className='btn-outline'><BsMicMute className='text-indigo-800 mr-1' /> {t('pages.player.actions.mute')}</Button>
           </Link>}
       </div>
       <div>
         {canCreateWarning &&
           <Link href={`/player/${id}/warn`} passHref>
-            <Button data-cy='action-warn' className='btn-outline'><AiOutlineWarning className='text-amber-800 mr-1' /> Warn</Button>
+            <Button data-cy='action-warn' className='btn-outline'><AiOutlineWarning className='text-amber-800 mr-1' /> {t('pages.player.actions.warning')}</Button>
           </Link>}
       </div>
       <div>
         {canCreateNote &&
           <Link href={`/player/${id}/note`} passHref>
-            <Button data-cy='action-note' className='btn-outline'><FaStickyNote className='text-emerald-700 mr-1' /> Note</Button>
+            <Button data-cy='action-note' className='btn-outline'><FaStickyNote className='text-emerald-700 mr-1' /> {t('pages.player.actions.note')}</Button>
           </Link>}
       </div>
     </div>

--- a/components/player/PlayerBans.js
+++ b/components/player/PlayerBans.js
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslations } from 'next-intl'
 import Loader from '../Loader'
 import ServerSelector from '../admin/ServerSelector'
 import { useApi } from '../../utils'
@@ -33,6 +34,7 @@ query listPlayerPunishmentRecords($serverId: ID!, $player: UUID!, $type: RecordT
 }`
 
 export default function PlayerBans ({ id }) {
+  const t = useTranslations()
   const [tableState, setTableState] = useState({ type: 'PlayerBanRecord', serverId: null })
   const { loading, data, mutate } = useApi({ query: !tableState.serverId ? null : query, variables: { ...tableState, player: id } })
 
@@ -50,7 +52,7 @@ export default function PlayerBans ({ id }) {
         className='pb-4 mb-4 border-b border-red-800' id='bans'
       >
         <div className='flex items-center'>
-          <p className='mr-6 text-xl font-bold '>Past Bans ({total})</p>
+          <p className='mr-6 text-xl font-bold '>{t('pages.player.pastBans', { total })}</p>
           <div className='w-40 inline-block'>
             <ServerSelector
               onChange={serverId => setTableState({ ...tableState, serverId })}
@@ -65,7 +67,7 @@ export default function PlayerBans ({ id }) {
       {!data?.listPlayerPunishmentRecords?.total && (
         <div className='flex items-center'>
           <div>
-            None
+            {t('common.none')}
           </div>
         </div>
       )}

--- a/components/player/PlayerHistoryList.js
+++ b/components/player/PlayerHistoryList.js
@@ -1,6 +1,9 @@
 import { Fragment, useMemo, useState, useEffect, useRef, useCallback } from 'react'
+import { useLocale, useTranslations } from 'next-intl'
 import Loader from '../Loader'
 import { useApi, useUser } from '../../utils'
+import { LOCALE_CONFIG, DEFAULT_LOCALE } from '../../utils/locale'
+import { useDateFnsLocale } from '../../utils/format-distance'
 import ServerSelector from '../admin/ServerSelector'
 import { TimeDuration } from '../Time'
 import { format, fromUnixTime } from 'date-fns'
@@ -12,6 +15,10 @@ import Link from 'next/link'
 const limit = 30
 
 export default function PlayerHistoryList ({ id, lastSeen }) {
+  const t = useTranslations()
+  const locale = useLocale()
+  const dateFnsLocale = useDateFnsLocale()
+  const dateFormat = LOCALE_CONFIG[locale]?.dateFormat || LOCALE_CONFIG[DEFAULT_LOCALE].dateFormat
   const { hasPermission, hasServerPermission } = useUser()
   const [isOpen, setIsOpen] = useState(false)
   const [tableState, setTableState] = useState({ offset: 0, serverId: null })
@@ -69,20 +76,27 @@ export default function PlayerHistoryList ({ id, lastSeen }) {
   }, [lastElementRef.current, total, handleObserver, tableState.serverId])
 
   const rowsGroupedByDate = useMemo(() => rows?.reduce((acc, { id, ...row }) => {
-    const date = format(fromUnixTime(row.join), 'dd MMM yyyy')
+    let date
+
+    try {
+      date = format(fromUnixTime(row.join), dateFormat, dateFnsLocale ? { locale: dateFnsLocale } : undefined)
+    } catch {
+      date = format(fromUnixTime(row.join), dateFormat)
+    }
+
     if (!acc[date]) {
       acc[date] = []
     }
     acc[date].push({ id, row })
     return acc
-  }, {}), [rows])
+  }, {}), [rows, dateFormat, dateFnsLocale])
 
   return (
     <>
       <Modal
-        title='History'
+        title={t('pages.player.history')}
         open={isOpen}
-        cancelButton='Close'
+        cancelButton={t('pages.player.close')}
         onCancel={() => setIsOpen(false)}
         containerClassName='md:max-w-3xl'
       >
@@ -109,8 +123,17 @@ export default function PlayerHistoryList ({ id, lastSeen }) {
           ))}
           {!loading && rows.length === 0 && (
             <>
-              <div className='p-2 text-center text-gray-400'>No history</div>
-              {hasPermission('servers', 'manage') && <div className='p-2 text-center text-gray-400'>If you&apos;re missing data here, ensure <Link target='_blank' href='https://banmanagement.com/docs/banmanager/configuration/config-yml#logips' rel='noreferrer'><pre className='inline'>logIps</pre></Link> is enabled in the plugin&apos;s config.yml file</div>}
+              <div className='p-2 text-center text-gray-400'>{t('pages.player.noHistory')}</div>
+              {hasPermission('servers', 'manage') &&
+                <div className='p-2 text-center text-gray-400'>
+                  {t.rich('pages.player.missingDataLine', {
+                    docs: (chunks) => (
+                      <Link target='_blank' href='https://banmanagement.com/docs/banmanager/configuration/config-yml#logips' rel='noreferrer'>
+                        <pre className='inline'>{chunks}</pre>
+                      </Link>
+                    )
+                  })}
+                </div>}
             </>)}
           <div ref={lastElementRef} />
         </div>

--- a/components/player/PlayerMutes.js
+++ b/components/player/PlayerMutes.js
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslations } from 'next-intl'
 import Loader from '../Loader'
 import ServerSelector from '../admin/ServerSelector'
 import { useApi } from '../../utils'
@@ -34,6 +35,7 @@ query listPlayerPunishmentRecords($serverId: ID!, $player: UUID!, $type: RecordT
 }`
 
 export default function PlayerMutes ({ id }) {
+  const t = useTranslations()
   const [tableState, setTableState] = useState({ type: 'PlayerMuteRecord', serverId: null })
   const { loading, data, mutate } = useApi({ query: !tableState.serverId ? null : query, variables: { ...tableState, player: id } })
 
@@ -51,7 +53,7 @@ export default function PlayerMutes ({ id }) {
         className='pb-4 mb-4 border-b border-indigo-800' id='mutes'
       >
         <div className='flex items-center'>
-          <p className='mr-6 text-xl font-bold '>Past Mutes ({total})</p>
+          <p className='mr-6 text-xl font-bold '>{t('pages.player.pastMutes', { total })}</p>
           <div className='w-40 inline-block'>
             <ServerSelector
               onChange={serverId => setTableState({ ...tableState, serverId })}
@@ -66,7 +68,7 @@ export default function PlayerMutes ({ id }) {
       {!data?.listPlayerPunishmentRecords?.total && (
         <div className='flex items-center'>
           <div>
-            None
+            {t('common.none')}
           </div>
         </div>
       )}

--- a/components/player/PlayerNotes.js
+++ b/components/player/PlayerNotes.js
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import Loader from '../Loader'
 import ServerSelector from '../admin/ServerSelector'
 import { useApi, useUser } from '../../utils'
@@ -30,6 +31,7 @@ query listPlayerPunishmentRecords($serverId: ID!, $player: UUID!, $type: RecordT
 }`
 
 export default function PlayerNotes ({ id }) {
+  const t = useTranslations()
   const { hasServerPermission } = useUser()
   const [tableState, setTableState] = useState({ type: 'PlayerNote', player: id, serverId: null })
   const { loading, data, mutate } = useApi({ query: !tableState.serverId ? null : query, variables: { ...tableState, player: id } })
@@ -49,7 +51,7 @@ export default function PlayerNotes ({ id }) {
         className='pb-4 mb-4 border-b border-teal-800' id='notes'
       >
         <div className='flex items-center'>
-          <p className='mr-6 text-xl font-bold '>Notes ({total})</p>
+          <p className='mr-6 text-xl font-bold '>{t('pages.player.notes', { total })}</p>
           <div className='w-40 inline-block'>
             <ServerSelector
               onChange={serverId => setTableState({ ...tableState, serverId })}
@@ -66,9 +68,9 @@ export default function PlayerNotes ({ id }) {
           <div>
             {canCreateNote &&
               <Link href={`/player/${id}/note`} passHref>
-                <Button className='btn-outline'><BiNotepad className='text-teal-800 mr-1' />Add Note</Button>
+                <Button className='btn-outline'><BiNotepad className='text-teal-800 mr-1' />{t('pages.player.addNote')}</Button>
               </Link>}
-            {!canCreateNote && 'None'}
+            {!canCreateNote && t('common.none')}
           </div>
         </div>
       )}

--- a/components/player/PlayerPunishment.js
+++ b/components/player/PlayerPunishment.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import { FaPencilAlt } from 'react-icons/fa'
 import { GoReport } from 'react-icons/go'
 import { BsTrash } from 'react-icons/bs'
@@ -63,6 +64,7 @@ const metaMap = {
 }
 
 export default function PlayerPunishment ({ punishment, server, type, onDeleted }) {
+  const t = useTranslations()
   const meta = metaMap[type]
   const [open, setOpen] = useState(false)
 
@@ -115,7 +117,7 @@ export default function PlayerPunishment ({ punishment, server, type, onDeleted 
         </div>
         <div className='ml-auto self-start flex flex-col justify-center items-center gap-2'>
           {label}
-          {punishment.read && <TiTick className='text-green-500' title='Read' />}
+          {punishment.read && <TiTick className='text-green-500' title={t('pages.punishment.read')} />}
         </div>
       </div>
       <div className='flex flex-col'>
@@ -127,16 +129,16 @@ export default function PlayerPunishment ({ punishment, server, type, onDeleted 
           {punishment.acl.delete &&
             <>
               <Modal
-                title={`Delete ${type}`}
-                confirmButton='Delete'
+                title={t(`pages.punishment.deleteTitle.${type}`)}
+                confirmButton={t('common.delete')}
                 open={open}
                 onConfirm={handleConfirmDelete}
                 onCancel={handleDeleteCancel}
                 loading={loading}
               >
                 <ErrorMessages errors={errors} />
-                <p className='pb-1'>Are you sure you want to delete this {type}?</p>
-                <p className='pb-1'>This action cannot be undone</p>
+                <p className='pb-1'>{t(`pages.punishment.deleteConfirm.${type}`)}</p>
+                <p className='pb-1'>{t('pages.punishment.actionUndoable')}</p>
               </Modal>
               <div>
                 <Button className='mt-4 bg-red-800' onClick={showConfirmDelete}>
@@ -145,7 +147,7 @@ export default function PlayerPunishment ({ punishment, server, type, onDeleted 
               </div>
             </>}
           {punishment.acl.yours &&
-            <Link href={`/appeal/punishment/${punishment.server.id}/${type}/${punishment.id}/`} className='ml-auto' title='Appeal'>
+            <Link href={`/appeal/punishment/${punishment.server.id}/${type}/${punishment.id}/`} className='ml-auto' title={t('pages.punishment.appeal')}>
               <Button className='bg-emerald-800 mt-4'><GoReport className='text-sm' /></Button>
             </Link>}
         </div>

--- a/components/player/PlayerStatistics.js
+++ b/components/player/PlayerStatistics.js
@@ -1,12 +1,14 @@
 import { FaBan } from 'react-icons/fa'
 import { BsMicMute } from 'react-icons/bs'
 import { AiOutlineWarning } from 'react-icons/ai'
+import { useTranslations } from 'next-intl'
 import ErrorMessages from '../ErrorMessages'
 import Loader from '../Loader'
 import { useApi } from '../../utils'
 import Link from 'next/link'
 
 const PlayerStatistics = ({ id }) => {
+  const t = useTranslations()
   const { loading, data, errors } = useApi({
     variables: { id }, query: `query playerStatistics($id: UUID!) {
       playerStatistics(player: $id) {
@@ -30,7 +32,7 @@ const PlayerStatistics = ({ id }) => {
           <div className='py-4 transform transition duration-500 hover:scale-110 justify-center items-center flex flex-col gap-1'>
             <FaBan className='w-8 h-8 inline-block text-red-800' />
             <h2 className='title-font font-medium'>{data.playerStatistics.totalBans + data.playerStatistics.totalActiveBans}</h2>
-            <p className='text-sm text-gray-400'>Bans</p>
+            <p className='text-sm text-gray-400'>{t('pages.player.statistics.bans')}</p>
           </div>
         </Link>
       </div>
@@ -39,7 +41,7 @@ const PlayerStatistics = ({ id }) => {
           <div className='py-4 transform transition duration-500 hover:scale-110 justify-center items-center flex flex-col gap-1'>
             <BsMicMute className='w-8 h-8 inline-block text-indigo-800' />
             <h2 className='title-font font-medium'>{data.playerStatistics.totalMutes + data.playerStatistics.totalActiveMutes}</h2>
-            <p className='text-sm text-gray-400'>Mutes</p>
+            <p className='text-sm text-gray-400'>{t('pages.player.statistics.mutes')}</p>
           </div>
         </Link>
       </div>
@@ -48,7 +50,7 @@ const PlayerStatistics = ({ id }) => {
           <div className='py-4 transform transition duration-500 hover:scale-110 justify-center items-center flex flex-col gap-1'>
             <AiOutlineWarning className='w-8 h-8 inline-block text-amber-800' />
             <h2 className='title-font font-medium'>{data.playerStatistics.totalWarnings}</h2>
-            <p className='text-sm text-gray-400'>Warnings</p>
+            <p className='text-sm text-gray-400'>{t('pages.player.statistics.warnings')}</p>
           </div>
         </Link>
       </div>

--- a/components/player/PlayerWarnings.js
+++ b/components/player/PlayerWarnings.js
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslations } from 'next-intl'
 import Loader from '../Loader'
 import ServerSelector from '../admin/ServerSelector'
 import { useApi } from '../../utils'
@@ -31,6 +32,7 @@ query listPlayerPunishmentRecords($serverId: ID!, $player: UUID!, $type: RecordT
 }`
 
 export default function PlayerWarnings ({ id }) {
+  const t = useTranslations()
   const [tableState, setTableState] = useState({ player: id, serverId: null, type: 'PlayerWarning' })
   const { loading, data, mutate } = useApi({ query: !tableState.serverId ? null : query, variables: { ...tableState, player: id } })
 
@@ -49,7 +51,7 @@ export default function PlayerWarnings ({ id }) {
         className='pb-4 mb-4 border-b border-amber-800' id='warnings'
       >
         <div className='flex items-center'>
-          <p className='mr-6 text-xl font-bold '>Warnings ({total})
+          <p className='mr-6 text-xl font-bold '>{t('pages.player.warnings', { total })}
             <div className='text-sm text-gray-400 flex items-center gap-4'>
               <div className='flex items-center gap-1'>
                 <RiNumbersLine />
@@ -71,7 +73,7 @@ export default function PlayerWarnings ({ id }) {
       {!data?.listPlayerPunishmentRecords?.total && (
         <div className='flex items-center'>
           <div>
-            None
+            {t('common.none')}
           </div>
         </div>
       )}

--- a/components/reports/PlayerReportAssign.js
+++ b/components/reports/PlayerReportAssign.js
@@ -1,10 +1,12 @@
 import { useEffect } from 'react'
+import { useTranslations } from 'next-intl'
 import Loader from '../Loader'
 import PlayerSelector from '../admin/PlayerSelector'
 import { useMutateApi } from '../../utils'
 import ErrorMessages from '../ErrorMessages'
 
 export default function PlayerReportAssign ({ id, player, server, onChange }) {
+  const t = useTranslations('forms')
   const { data, loading, load, errors } = useMutateApi({
     query: /* GraphQL */ `
       mutation assignReport($report: ID!, $serverId: ID!, $player: UUID!) {
@@ -43,7 +45,7 @@ export default function PlayerReportAssign ({ id, player, server, onChange }) {
       <PlayerSelector
         multiple={false}
         onChange={handleChange}
-        placeholder='Search by player name'
+        placeholder={t('playerSelectorPlaceholder')}
         defaultValue={player ? ({ value: player.id, label: <PlayerSelector.Label player={player} /> }) : null}
       />
     </>

--- a/components/reports/PlayerReportCommand.js
+++ b/components/reports/PlayerReportCommand.js
@@ -1,8 +1,23 @@
 import Link from 'next/link'
 import { format, fromUnixTime } from 'date-fns'
+import { useLocale } from 'next-intl'
 import Avatar from '../Avatar'
+import { LOCALE_CONFIG, DEFAULT_LOCALE } from '../../utils/locale'
+import { useDateFnsLocale } from '../../utils/format-distance'
 
 export default function PlayerReportCommand ({ command }) {
+  const locale = useLocale()
+  const dateFnsLocale = useDateFnsLocale()
+  const dateFormat = `${LOCALE_CONFIG[locale]?.dateFormat || LOCALE_CONFIG[DEFAULT_LOCALE].dateFormat} HH:mm:ss`
+
+  let formatted
+
+  try {
+    formatted = format(fromUnixTime(command.created), dateFormat, dateFnsLocale ? { locale: dateFnsLocale } : undefined)
+  } catch {
+    formatted = format(fromUnixTime(command.created), dateFormat)
+  }
+
   return (
     <li>
       <div className='flex items-center space-x-4'>
@@ -16,7 +31,7 @@ export default function PlayerReportCommand ({ command }) {
               {command.actor.name}
 
             </Link>
-            <span className='text-xs text-gray-400 ml-1'>{format(fromUnixTime(command.created), 'dd MMM yyyy HH:mm:ss')}</span>
+            <span className='text-xs text-gray-400 ml-1'>{formatted}</span>
           </p>
           <pre className='text-sm text-gray-400 truncate overflow-y-auto'>/{command.command} {command.args}</pre>
         </div>

--- a/components/reports/PlayerReportComment.js
+++ b/components/reports/PlayerReportComment.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import ErrorMessages from '../ErrorMessages'
 import Modal from '../Modal'
 import { fromNow, useMutateApi } from '../../utils'
@@ -7,6 +8,7 @@ import Avatar from '../Avatar'
 import DocumentGallery from '../DocumentGallery'
 
 export default function PlayerReportComment ({ id, actor, created, comment, acl, documents, serverId, onFinish }) {
+  const t = useTranslations()
   const [open, setOpen] = useState(false)
   const { load, data, loading, errors } = useMutateApi({
     query: `mutation deleteReportComment($id: ID!, $serverId: ID!) {
@@ -42,33 +44,31 @@ export default function PlayerReportComment ({ id, actor, created, comment, acl,
         <Avatar uuid={actor.id} width={40} height={40} className='mx-1 inline-block relative' />
       </Link>
       <Modal
-        title='Delete comment'
-        confirmButton='Delete'
+        title={t('pages.appeals.deleteCommentTitle')}
+        confirmButton={t('common.delete')}
         open={open}
         onConfirm={handleConfirmDelete}
         onCancel={handleDeleteCancel}
         loading={loading}
       >
         <ErrorMessages errors={errors} />
-        <p className='pb-1'>Are you sure you want to delete this comment?</p>
-        <p className='pb-1'>This action cannot be undone</p>
+        <p className='pb-1'>{t('pages.appeals.deleteCommentConfirm')}</p>
+        <p className='pb-1'>{t('pages.punishment.actionUndoable')}</p>
       </Modal>
       <div className='-ml-8 md:-ml-4 rounded-3xl bg-primary-900'>
         <div className='rounded-tl rounded-tr relative justify-between items-center flex border-b border-primary-400 py-2 px-4 text-sm text-gray-300'>
           <div className='items-center flex'>
             <span>
-              <Link href={`/player/${actor.id}`} className='font-semibold'>
-                {actor.name}
-              </Link> commented&nbsp;
-              <Link href={`#comment-${id}`}>
-
-                <span>{fromNow(created)}</span>
-
-              </Link>
+              {t.rich('pages.appeals.commentedAt', {
+                actorName: actor.name,
+                relative: fromNow(created),
+                actor: (chunks) => <Link href={`/player/${actor.id}`} className='font-semibold'>{chunks}</Link>,
+                time: (chunks) => <Link href={`#comment-${id}`}><span>{chunks}</span></Link>
+              })}
             </span>
           </div>
           <div className='items-center flex'>
-            {acl?.delete && <a className='cursor-pointer' onClick={showConfirmDelete}>Delete</a>}
+            {acl?.delete && <a className='cursor-pointer' onClick={showConfirmDelete}>{t('common.delete')}</a>}
           </div>
         </div>
         <div className='rounded-bl rounded-br relative p-4 top-0 bottom-0'>

--- a/components/reports/PlayerReportServerLogs.js
+++ b/components/reports/PlayerReportServerLogs.js
@@ -1,9 +1,16 @@
 import { useState, Fragment, useMemo } from 'react'
+import { useLocale, useTranslations } from 'next-intl'
 import Modal from '../Modal'
 import { format, fromUnixTime } from 'date-fns'
 import Button from '../Button'
+import { LOCALE_CONFIG, DEFAULT_LOCALE } from '../../utils/locale'
+import { useDateFnsLocale } from '../../utils/format-distance'
 
 export default function PlayerReportServerLogs ({ serverLogs }) {
+  const t = useTranslations('pages.report')
+  const locale = useLocale()
+  const dateFnsLocale = useDateFnsLocale()
+  const dateFormat = LOCALE_CONFIG[locale]?.dateFormat || LOCALE_CONFIG[DEFAULT_LOCALE].dateFormat
   const [isOpen, setIsOpen] = useState(false)
 
   if (!serverLogs?.length) {
@@ -11,20 +18,27 @@ export default function PlayerReportServerLogs ({ serverLogs }) {
   }
 
   const logsGroupedByDate = useMemo(() => serverLogs?.reduce((acc, { id, log }) => {
-    const date = format(fromUnixTime(log.created), 'dd MMM yyyy')
+    let date
+
+    try {
+      date = format(fromUnixTime(log.created), dateFormat, dateFnsLocale ? { locale: dateFnsLocale } : undefined)
+    } catch {
+      date = format(fromUnixTime(log.created), dateFormat)
+    }
+
     if (!acc[date]) {
       acc[date] = []
     }
     acc[date].push({ id, log })
     return acc
-  }, {}), [serverLogs])
+  }, {}), [serverLogs, dateFormat, dateFnsLocale])
 
   return (
     <>
       <Modal
-        title='Server Logs'
+        title={t('serverLogs')}
         open={isOpen}
-        cancelButton='Close'
+        cancelButton={t('close')}
         onCancel={() => setIsOpen(false)}
         containerClassName='md:max-w-3xl'
       >
@@ -44,8 +58,8 @@ export default function PlayerReportServerLogs ({ serverLogs }) {
           ))}
         </div>
       </Modal>
-      <p className='text-sm text-gray-400 pb-3'>This report has {serverLogs?.length} records associated with it</p>
-      <Button className='bg-primary-900 text-gray-400 font-normal' onClick={() => setIsOpen(true)}>Review Logs</Button>
+      <p className='text-sm text-gray-400 pb-3'>{t('reportRecords', { count: serverLogs?.length })}</p>
+      <Button className='bg-primary-900 text-gray-400 font-normal' onClick={() => setIsOpen(true)}>{t('reviewLogs')}</Button>
     </>
   )
 }

--- a/components/reports/PlayerReportSidebar.js
+++ b/components/reports/PlayerReportSidebar.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import SidebarDocuments from '../SidebarDocuments'
 import PlayerReportActions from './PlayerReportActions'
 import PlayerReportAssign from './PlayerReportAssign'
@@ -21,11 +22,13 @@ const SidebarItem = ({ title, children }) => (
 )
 
 export default function PlayerReportSidebar ({ data, canUpdateState, canAssign, stateOptions, mutate, user }) {
+  const t = useTranslations('pages.appeals.sidebar')
+  const tReport = useTranslations('pages.report')
   const report = data?.report
 
   return (
     <ul role='list' className='divide-y divide-primary-900'>
-      <SidebarItem title='State'>
+      <SidebarItem title={t('state')}>
         <div data-cy='report-state'>
           {canUpdateState
             ? (
@@ -41,7 +44,7 @@ export default function PlayerReportSidebar ({ data, canUpdateState, canAssign, 
             : (<p className='text-sm' data-cy='report-state-display'>{report?.state?.name}</p>)}
         </div>
       </SidebarItem>
-      <SidebarItem title='Assignee'>
+      <SidebarItem title={t('assignee')}>
         <div data-cy='report-assignee'>
           {canAssign
             ? (
@@ -53,11 +56,11 @@ export default function PlayerReportSidebar ({ data, canUpdateState, canAssign, 
                   mutate({ ...data, report: { ...data.report, assignee, updated } }, false)
                 }}
               />)
-            : (<p className='text-sm' data-cy='report-assignee-display'>{report?.assignee?.name || 'Unassigned'}</p>)}
+            : (<p className='text-sm' data-cy='report-assignee-display'>{report?.assignee?.name || t('unassigned')}</p>)}
         </div>
       </SidebarItem>
       {!!user &&
-        <SidebarItem title='Notifications'>
+        <SidebarItem title={t('notifications')}>
           <PlayerReportNotifications
             report={report}
             server={data.server}
@@ -67,22 +70,22 @@ export default function PlayerReportSidebar ({ data, canUpdateState, canAssign, 
           />
         </SidebarItem>}
       {(report.playerLocation || report.actorLocation) &&
-        <SidebarItem title='Locations'>
+        <SidebarItem title={tReport('locations')}>
           <ul className='space-y-4'>
             {report.playerLocation && <PlayerReportLocation location={report.playerLocation} player={report.player} />}
             {report.actorLocation && <PlayerReportLocation location={report.actorLocation} player={report.actor} />}
           </ul>
         </SidebarItem>}
       {report.serverLogs && !!report.serverLogs.length &&
-        <SidebarItem title='Server Logs'>
+        <SidebarItem title={tReport('serverLogs')}>
           <PlayerReportServerLogs serverLogs={report.serverLogs} />
         </SidebarItem>}
       {report.documents?.length > 0 &&
-        <SidebarItem title='Documents'>
+        <SidebarItem title={t('documents')}>
           <SidebarDocuments documents={report.documents} />
         </SidebarItem>}
       {((!!user && report.state.id < 3 && !report?.commands?.length) || !!report?.commands?.length) &&
-        <SidebarItem title='Actions'>
+        <SidebarItem title={t('actions')}>
           {!!report?.commands?.length &&
             <ul role='list' className='divide-y divide-primary-900'>
               {report.commands.map(cmd => (

--- a/messages/de.json
+++ b/messages/de.json
@@ -15,7 +15,16 @@
     "no": "Nein",
     "ok": "OK",
     "siteName": "Ban Management",
-    "version": "Version"
+    "version": "Version",
+    "add": "Hinzufügen",
+    "none": "Keine",
+    "all": "Alle",
+    "warning": "Warnung",
+    "test": "Testen",
+    "send": "Senden",
+    "create": "Erstellen",
+    "comment": "Kommentieren",
+    "permanent": "Dauerhaft"
   },
   "nav": {
     "login": "Anmelden",
@@ -23,12 +32,15 @@
     "language": "Sprache",
     "home": "Startseite",
     "openMenu": "Menü öffnen",
+    "closeMenu": "Menü schließen",
     "admin": "Administration",
     "dashboard": "Dashboard",
     "notifications": "Benachrichtigungen",
     "account": "Konto",
     "profile": "Profil",
-    "viewProfile": "Profil anzeigen"
+    "viewProfile": "Profil anzeigen",
+    "settings": "Einstellungen",
+    "return": "Zurück"
   },
   "footer": {
     "powered": "Bereitgestellt von"
@@ -41,7 +53,12 @@
     },
     "register": {
       "title": "Registrieren",
-      "subtitle": "Erstelle dein Konto"
+      "subtitle": "Erstelle dein Konto",
+      "documentTitle": "Registrieren | Konto",
+      "feature1": "Anmelden überall, jederzeit",
+      "feature2": "Alle Strafen einschließlich Meldungen verfolgen",
+      "feature3": "Benachrichtigungen zu Einspruchsaktualisierungen",
+      "skip": "Überspringen"
     },
     "forgottenPassword": {
       "title": "Passwort vergessen",
@@ -51,9 +68,23 @@
       "title": "Einspruch erstellen",
       "subtitle": "Reiche einen Einspruch gegen eine Strafe ein",
       "documentTitle": "Einspruch",
+      "punishmentDocumentTitle": "Strafe auswählen | Einspruch",
+      "pinLoginDocument": "Anmelden | Einspruch",
+      "accountLoginDocument": "Anmelden | Einspruch",
+      "accountLogin": "Konto-Anmeldung",
+      "appealBan": "Einspruch gegen Bann",
+      "appealMute": "Einspruch gegen Stummschaltung",
+      "appealWarning": "Einspruch gegen Verwarnung",
+      "appealBanDocument": "Einspruch gegen Bann | Einspruch",
+      "appealMuteDocument": "Einspruch gegen Stummschaltung | Einspruch",
+      "appealWarningDocument": "Einspruch gegen Verwarnung | Einspruch",
+      "punishmentNotFound": "Strafe nicht gefunden",
+      "headBack": "Gehe zurück zur vorherigen Seite",
       "stepHeader": {
         "step1": "PIN-Anmeldung",
-        "selectPunishment": "Strafe auswählen"
+        "selectPunishment": "Strafe auswählen",
+        "writeAppeal": "Einspruch verfassen",
+        "awaitReview": "Auf Überprüfung warten"
       },
       "intro": "Zuerst müssen wir wissen, wer du bist.",
       "pinHelp": "Ich habe einen 6-stelligen PIN, z.B. ",
@@ -61,14 +92,61 @@
       "pinExpiry": "Hinweis: Dieser PIN läuft nach 5 Minuten ab.",
       "or": "ODER",
       "haveAccount": "Ich habe bereits ein Konto",
-      "haveAccountDescription": "Dies ist spezifisch für diese Website und NICHT deine Microsoft/Mojang-Anmeldedaten."
+      "haveAccountDescription": "Dies ist spezifisch für diese Website und NICHT deine Microsoft/Mojang-Anmeldedaten.",
+      "noPunishments": "Keine Strafen gefunden",
+      "tryChangingFilters": "Versuche deine Filter zu ändern",
+      "clearFilters": "Filter zurücksetzen",
+      "reasonLabel": "Warum sollte diese Strafe aufgehoben werden?",
+      "reasonPlaceholder": "Erkläre, warum diese Strafe aufgehoben werden sollte..."
     },
     "account": {
       "documentTitle": "Konto",
       "subtitle": "Konto",
       "register": "Registrieren",
       "email": "E-Mail",
-      "password": "Passwort"
+      "password": "Passwort",
+      "changeEmail": "E-Mail-Adresse ändern",
+      "changePassword": "Passwort ändern",
+      "changeEmailDocumentTitle": "E-Mail-Adresse ändern | Konto",
+      "changePasswordDocumentTitle": "Passwort ändern | Konto",
+      "newEmail": "Neue E-Mail-Adresse",
+      "newPassword": "Neues Passwort",
+      "confirmNewPassword": "Neues Passwort bestätigen",
+      "passwordHint": "Muss mindestens 6 Zeichen lang sein"
+    },
+    "home": {
+      "documentTitle": "Willkommen",
+      "appeal": {
+        "subtitle": "Hilfe, ich wurde gebannt",
+        "title": "Einspruch",
+        "intro": "Wenn du glaubst, dass dein Konto zu Unrecht bestraft wurde, erstelle einen Einspruch und begründe ihn mit allen relevanten Beweisen.",
+        "warning": "Es gibt keine Garantie, dass dein Einspruch erfolgreich sein wird.",
+        "cta": "Einspruch erstellen"
+      },
+      "search": {
+        "subtitle": "Spieler suchen",
+        "title": "Suche",
+        "intro": "Sieh dir die vollständige Strafenhistorie eines Spielers an, einschließlich aktueller Banns, Stummschaltungen und mehr!",
+        "placeholder": "Spielernamen eingeben"
+      },
+      "account": {
+        "signInTitle": "Anmelden",
+        "signInSubtitle": "Hast du bereits ein Konto?",
+        "myAccountSubtitle": "Mein Konto",
+        "dashboardCta": "Mein Dashboard"
+      }
+    },
+    "dashboard": {
+      "title": "Dashboard",
+      "documentTitle": "Dashboard",
+      "appealsDocumentTitle": "Einsprüche | Dashboard",
+      "reportsDocumentTitle": "Meldungen | Dashboard",
+      "activePunishments": "Aktive Strafen",
+      "yourAppeals": "Deine Einsprüche",
+      "yourReports": "Deine Meldungen",
+      "appeals": "Einsprüche",
+      "reports": "Meldungen",
+      "viewAll": "Alle anzeigen"
     },
     "notFound": {
       "title": "Hoppla! Seite nicht gefunden",
@@ -87,21 +165,345 @@
       "intro": "Es tut uns leid, bei uns ist etwas schiefgelaufen. Bitte versuche es später erneut.",
       "documentTitle": "Serverfehler"
     },
+    "notifications": {
+      "title": "Benachrichtigungen",
+      "documentTitle": "Benachrichtigungen",
+      "empty": "Hier gibt es noch nichts zu sehen"
+    },
+    "appeals": {
+      "documentTitle": "#{id} | {name} | {reason} | Einspruch",
+      "appealingSentence": "<actor>{actorName}</actor> legt Einspruch gegen einen {kind, select, permanent {permanenten <badge></badge> ein, ausgestellt am {issuedDate} von <punisher>{punisherName}</punisher>} other {temporären <badge></badge> ein, ausgestellt am {issuedDate} von <punisher>{punisherName}</punisher> (läuft {expiresTime} ab)}}",
+      "commentedAt": "<actor>{actorName}</actor> kommentierte <time>{relative}</time>",
+      "deleteCommentTitle": "Kommentar löschen",
+      "deleteCommentConfirm": "Bist du sicher, dass du diesen Kommentar löschen möchtest?",
+      "updates": {
+        "reasonChanged": "<actor>{actorName}</actor> änderte den Grund von <old>{oldReason}</old> in <new>{newReason}</new>",
+        "expirationChanged": "<actor>{actorName}</actor> änderte das Ablaufdatum von <old>{oldExpires}</old> auf <new>{newExpires}</new>",
+        "softChanged": "<actor>{actorName}</actor> setzte <old>{oldSoft}</old> auf <new>{newSoft}</new>",
+        "stateMarked": "<actor>{actorName}</actor> markierte diesen Einspruch als {state} {time}",
+        "shadow": "Shadow",
+        "notShadow": "Nicht Shadow",
+        "permanent": "permanent"
+      },
+      "sidebar": {
+        "state": "Status",
+        "assignee": "Zuständig",
+        "unassigned": "Nicht zugewiesen",
+        "notifications": "Benachrichtigungen",
+        "documents": "Dokumente",
+        "actions": "Aktionen"
+      },
+      "actions": {
+        "editBan": "Bann bearbeiten",
+        "editMute": "Stummschaltung bearbeiten",
+        "editWarning": "Verwarnung bearbeiten",
+        "unban": "Entbannen",
+        "unmute": "Entstummen",
+        "deleteWarning": "Verwarnung löschen"
+      },
+      "editTitle": {
+        "ban": "Bann bearbeiten",
+        "mute": "Stummschaltung bearbeiten",
+        "warning": "Verwarnung bearbeiten"
+      },
+      "removeTitle": {
+        "ban": "Bann entfernen",
+        "mute": "Stummschaltung entfernen",
+        "warning": "Verwarnung entfernen"
+      },
+      "removeConfirm": {
+        "ban": "Bist du sicher, dass du diesen Bann entfernen möchtest?",
+        "mute": "Bist du sicher, dass du diese Stummschaltung entfernen möchtest?",
+        "warning": "Bist du sicher, dass du diese Verwarnung entfernen möchtest?"
+      }
+    },
+    "report": {
+      "serverLogs": "Server-Protokolle",
+      "close": "Schließen",
+      "reportRecords": "{count, plural, one {Diese Meldung hat 1 zugehörigen Eintrag} other {Diese Meldung hat # zugehörige Einträge}}",
+      "reviewLogs": "Protokolle prüfen",
+      "locations": "Standorte",
+      "documentTitle": "#{id} | {name} | {reason} | Meldung",
+      "reportedSentence": "<actor>{actorName}</actor> meldete <player>{playerName}</player> am {date}"
+    },
+    "player": {
+              "statistics": {
+                "bans": "Banns",
+                "mutes": "Stummschaltungen",
+                "warnings": "Verwarnungen"
+              },
+              "actions": {
+                "ban": "Bannen",
+                "mute": "Stummschalten",
+                "warning": "Verwarnen",
+                "note": "Notiz"
+              },
+              "activeBans": "{total, plural, one {Aktiver Bann (1)} other {Aktive Banns (#)}}",
+              "activeMutes": "{total, plural, one {Aktive Stummschaltung (1)} other {Aktive Stummschaltungen (#)}}",
+              "pastBans": "{total, plural, one {Früherer Bann (1)} other {Frühere Banns (#)}}",
+              "pastMutes": "{total, plural, one {Frühere Stummschaltung (1)} other {Frühere Stummschaltungen (#)}}",
+              "warnings": "{total, plural, one {Verwarnung (1)} other {Verwarnungen (#)}}",
+              "notes": "{total, plural, one {Notiz (1)} other {Notizen (#)}}",
+              "addNote": "Notiz hinzufügen",
+              "kicks": "{total, plural, one {Kick (1)} other {Kicks (#)}}",
+              "pastKicks": "{total, plural, one {Früherer Kick (1)} other {Frühere Kicks (#)}}",
+              "alts": "Zweitkonten",
+              "history": "Verlauf",
+              "playerHistory": "Spielerverlauf",
+              "noHistory": "Kein Verlauf",
+              "missingDataLine": "Wenn dir hier Daten fehlen, stelle sicher, dass <docs>logIps</docs> in der config.yml-Datei des Plugins aktiviert ist",
+              "close": "Schließen",
+              "lastSeen": "Zuletzt gesehen {time}",
+              "neverSeen": "Nie gesehen",
+              "actionTitles": {
+                "ban": "{name} bannen",
+                "mute": "{name} stummschalten",
+                "warn": "{name} verwarnen",
+                "note": "Notiz für {name}",
+                "addNoteHeader": "Notiz hinzufügen",
+                "addNoteDocument": "Notiz zu {name} hinzufügen",
+                "editBan": "Bann bearbeiten",
+                "editMute": "Stummschaltung bearbeiten",
+                "editWarning": "Verwarnung bearbeiten",
+                "editNote": "Notiz bearbeiten",
+                "editKick": "Kick bearbeiten",
+                "editBanDocument": "Bann von {name} bearbeiten",
+                "editMuteDocument": "Stummschaltung von {name} bearbeiten",
+                "editWarningDocument": "Verwarnung von {name} bearbeiten",
+                "editNoteDocument": "Notiz von {name} bearbeiten"
+              }
+            },
+    "punishment": {
+      "appeal": "Einspruch",
+      "read": "Gelesen",
+      "deleteTitle": {
+        "ban": "Bann löschen",
+        "mute": "Stummschaltung löschen",
+        "warning": "Verwarnung löschen",
+        "note": "Notiz löschen",
+        "kick": "Kick löschen"
+      },
+      "deleteConfirm": {
+        "ban": "Bist du sicher, dass du diesen Bann löschen möchtest?",
+        "mute": "Bist du sicher, dass du diese Stummschaltung löschen möchtest?",
+        "warning": "Bist du sicher, dass du diese Verwarnung löschen möchtest?",
+        "note": "Bist du sicher, dass du diese Notiz löschen möchtest?",
+        "kick": "Bist du sicher, dass du diesen Kick löschen möchtest?"
+      },
+      "actionUndoable": "Diese Aktion kann nicht rückgängig gemacht werden",
+      "deletionReasonUnknown": "Löschgrund unbekannt"
+    },
     "admin": {
       "title": "Administration",
+      "loading": "Wird geladen…",
       "developerMode": "Entwicklermodus",
       "developerModeMessage": "Du läufst aktuell im Entwicklungsmodus, erwarte Leistungseinbußen",
       "updateAvailable": "Update verfügbar",
       "currentVersion": "Aktuelle Version: {current}",
       "latestVersion": "Neueste: {latest}",
       "newFeatures": "Neue Funktionen",
-      "fixes": "Fehlerbehebungen"
+      "fixes": "Fehlerbehebungen",
+      "nav": {
+        "documents": "Dokumente",
+        "roles": "Rollen",
+        "servers": "Server",
+        "notificationRules": "Benachrichtigungsregeln",
+        "webhooks": "Webhooks"
+      },
+      "documents": {
+        "title": "Dokumente",
+        "uploadedCount": "{total, plural, one {# Dokument hochgeladen} other {# Dokumente hochgeladen}}",
+        "emptyTitle": "Keine Dokumente hochgeladen",
+        "emptySubtitle": "Dokumente, die an Einsprüche und Meldungen angehängt sind, erscheinen hier",
+        "document": "Dokument",
+        "uploadedBy": "Hochgeladen von",
+        "usedIn": "Verwendet in",
+        "date": "Datum",
+        "actions": "Aktionen",
+        "unknown": "Unbekannt",
+        "notAttached": "Nicht angehängt",
+        "viewFullSize": "In voller Größe anzeigen",
+        "openInNewTab": "In neuem Tab öffnen",
+        "deleteTitle": "Dokument löschen",
+        "deleteConfirm": "Möchtest du dieses Dokument wirklich löschen?",
+        "deleteWarning": "Diese Aktion kann nicht rückgängig gemacht werden und entfernt das Bild aus allen angehängten Einsprüchen.",
+        "deleteImage": "Bild löschen",
+        "deleteImageTitle": "Bild löschen",
+        "deleteImageConfirm": "Möchtest du dieses Bild wirklich löschen?"
+      },
+      "servers": {
+        "title": "Server",
+        "server": "Server",
+        "addServer": "Server hinzufügen",
+        "editServer": "Server bearbeiten",
+        "editTitle": "{name} bearbeiten",
+        "viewDocumentTitle": "{name} | Server",
+        "stats": {
+          "bans": "Banns",
+          "mutes": "Stummschaltungen",
+          "warnings": "Verwarnungen",
+          "reports": "Meldungen",
+          "total": "Gesamt",
+          "averageLength": "Ø-Dauer",
+          "averageResolution": "Ø-Lösungsdauer",
+          "lastDays": "Letzte {days} Tage"
+        },
+        "playerActivity": {
+          "title": "Spieleraktivität",
+          "newJoins": "Neuanmeldungen",
+          "uniquePlayers": "Einzigartige Spieler",
+          "summaryTitle": "Aktivitätszusammenfassung",
+          "filters": "Filter",
+          "startDate": "Startdatum",
+          "endDate": "Enddatum",
+          "actor": "Akteur",
+          "clear": "Zurücksetzen",
+          "limitWarning": "Ergebnisse sind begrenzt, verwende die Filter, um mehr zu sehen",
+          "for": "für",
+          "actions": {
+            "BAN": "Gebannt",
+            "IPBAN": "{ip} gebannt",
+            "UNBAN": "Entbannt",
+            "UNBANIP": "{ip} entbannt",
+            "IPRANGEBAN": "{fromIp} - {toIp} gebannt",
+            "IPRANGEUNBAN": "{fromIp} - {toIp} entbannt",
+            "MUTE": "Stummgeschaltet",
+            "IPMUTE": "{ip} stummgeschaltet",
+            "UNMUTE": "Entstummt",
+            "IPUNMUTE": "{ip} entstummt",
+            "WARNING": "Verwarnt",
+            "NOTE": "Hat eine Notiz erstellt für"
+          }
+        },
+        "deleteTitle": "Server löschen",
+        "deleteWarning": "Zugehörige <strong>Einsprüche und Rollen</strong> werden entfernt",
+        "deleteConfirmInstruction": "Bitte gib <strong>{name}</strong> ein, um zu bestätigen",
+        "deletePlaceholder": "Servername eingeben",
+        "form": {
+          "info": "Informationen",
+          "name": "Name",
+          "consoleUuid": "Konsolen-UUID (BanManager/console.yml)",
+          "yamlPlaceholder": "YAML BanManager/config.yml einfügen (optional)",
+          "database": "Datenbank",
+          "host": "Host",
+          "port": "Port",
+          "databaseName": "Datenbankname",
+          "user": "Benutzer",
+          "password": "Passwort",
+          "databaseTables": "Datenbanktabellen"
+        }
+      },
+      "roles": {
+        "title": "Rollen",
+        "addRole": "Rolle hinzufügen",
+        "editRole": "Rolle bearbeiten",
+        "editTitle": "{name} bearbeiten",
+        "deleteTitle": "Rolle löschen",
+        "deleteConfirm": "Bist du sicher, dass du diese Rolle löschen möchtest?",
+        "defaultUnauthenticated": "Wird standardmäßig allen nicht angemeldeten Besuchern zugewiesen",
+        "defaultAuthenticated": "Wird standardmäßig allen angemeldeten Spielern zugewiesen",
+        "superAdmin": "Super-Admin-Rolle mit allen Berechtigungen",
+        "tipsHeader": "Tipps",
+        "tip1": "Es gibt 3 Standardrollen, die automatisch zugewiesen werden. Diese Berechtigungen können geändert werden",
+        "tip2": "Erstelle und weise neue Rollen zu, um deinen Moderatoren Berechtigungen zur Verwaltung von Einsprüchen, Meldungen usw. zu erteilen.",
+        "tip3": "Ein Spieler kann mehrere Rollen haben und diese sind additiv, d.h. eine erteilte Berechtigung wird immer gewährt; Rollen können keine Berechtigung entfernen, die durch eine andere Rolle erteilt wurde",
+        "tip4": "Benutzerdefinierte Rollen müssen eine übergeordnete Rolle definieren; wenn neue Ressourcen und/oder Berechtigungen in einem Update zu den Standardrollen hinzugefügt werden, werden sie automatisch den untergeordneten Rollen gewährt",
+        "assignGlobal": "Globale Spielerrollen zuweisen",
+        "assignGlobalHint": "Hat Vorrang vor Serverrollen und gilt global",
+        "assignServer": "Server-Spielerrollen zuweisen",
+        "assignServerHint": "Betrifft nur bestimmte Aktionen, bei denen ein Server zutrifft, z.B. Banns",
+        "role": "Rolle",
+        "assign": "Zuweisen",
+        "form": {
+          "edit": "Rolle bearbeiten",
+          "name": "Name",
+          "resources": "Ressourcen",
+          "fullAccess": "{name} hat Zugriff auf alle Ressourcen"
+        }
+      },
+      "notificationRules": {
+        "title": "Benachrichtigungsregeln",
+        "addRule": "Regel hinzufügen",
+        "createRule": "Eine Regel erstellen",
+        "editTitle": "Benachrichtigungsregel #{id} bearbeiten",
+        "editTitleHeader": "Benachrichtigungsregel bearbeiten",
+        "emptyTitle": "Hier ist nichts",
+        "emptySubtitle": "Benachrichtigungsregeln werden hier erscheinen, versuche eine zu erstellen!",
+        "deleteTitle": "Benachrichtigungsregel löschen",
+        "deleteConfirm": "Bist du sicher, dass du diese Benachrichtigungsregel löschen möchtest?",
+        "form": {
+          "type": "Benachrichtigungstyp",
+          "roles": "Rollen",
+          "serverOptional": "Server (optional)",
+          "server": "Server"
+        }
+      },
+      "players": {
+        "globalRoles": "Globale Rollen",
+        "serverRoles": "Serverrollen",
+        "edit": "Bearbeiten"
+      },
+      "webhooks": {
+        "title": "Webhooks",
+        "addWebhook": "Webhook hinzufügen",
+        "addAWebhook": "Einen Webhook hinzufügen",
+        "addWebhookType": "{type}-Webhook hinzufügen",
+        "editTitle": "Webhook bearbeiten",
+        "editTitleDoc": "Webhook #{id} bearbeiten",
+        "deliveries": "Zustellungen",
+        "deliveriesTitle": "Webhook-Zustellungen",
+        "deliveriesDocumentTitle": "Webhook #{id} Zustellungen",
+        "deliveriesEmptyTitle": "Keine Webhook-Zustellungen",
+        "deliveriesEmptySubtitle": "Webhook-Zustellungen erscheinen hier, sobald der Webhook ausgelöst wurde.",
+        "delivery": {
+          "request": "Anfrage",
+          "response": "Antwort",
+          "headers": "Header",
+          "payload": "Nutzdaten",
+          "body": "Body",
+          "error": "Fehler"
+        },
+        "test": {
+          "errorPrefix": "Fehler beim Senden des Webhooks",
+          "content": "Inhalt"
+        },
+        "selectType": "Webhook-Typ auswählen",
+        "discord": "Discord",
+        "custom": "Benutzerdefiniert",
+        "invalidType": "Ungültiger Webhook-Typ",
+        "invalidJson": "Ungültiges JSON",
+        "emptyTitle": "Hier ist nichts",
+        "emptySubtitle": "Webhooks ermöglichen es externen Diensten, benachrichtigt zu werden, wenn ein Ereignis eintritt",
+        "deleteTitle": "Webhook löschen",
+        "deleteConfirm": "Bist du sicher, dass du diesen Webhook löschen möchtest?",
+        "testTitle": "Webhook testen",
+        "form": {
+          "eventType": "Ereignistyp",
+          "serverOptional": "Server (optional)",
+          "server": "Server",
+          "url": "URL",
+          "urlPlaceholderCustom": "https://example.com/webhook",
+          "urlPlaceholderDiscord": "https://discord.com/webhook",
+          "contentTemplate": "Inhaltsvorlage",
+          "contentHint": "Verwende die definierten Variablen, um den Inhalt anzupassen",
+          "contentPlaceholder": "{exampleJson}",
+          "availableVariables": "Verfügbare Variablen",
+          "preview": "Vorschau"
+        }
+      },
+      "layout": {
+        "viewProfile": "Profil anzeigen",
+        "settings": "Einstellungen",
+        "notifications": "Benachrichtigungen",
+        "return": "Zurück"
+      }
     }
   },
   "errors": {
     "header": "Fehler",
     "fetchHeader": "Abruffehler",
     "httpHeader": "HTTP-Fehler: {status}",
+    "somethingWentWrong": "Etwas ist schiefgelaufen",
     "invalidJson": "Ungültiges JSON",
     "INTERNAL": "Interner Serverfehler",
     "UNKNOWN": "Ein unbekannter Fehler ist aufgetreten",
@@ -171,12 +573,36 @@
     "name": "Name",
     "reason": "Grund",
     "message": "Nachricht",
+    "points": "Punkte",
+    "soft": "Soft",
+    "softDescription": "Verbirgt seine Nachrichten vor anderen, um Spam zu verhindern",
     "comment": "Schreibe hier deinen Kommentar…",
+    "commentPlaceholder": "Schreibe hier deinen Kommentar…",
     "playerSelectorPlaceholder": "Spieler suchen",
     "required": "Dieses Feld ist erforderlich",
     "minLength": "Muss mindestens {n} Zeichen lang sein",
     "maxLength": "Darf maximal {n} Zeichen lang sein",
     "passwordMismatch": "Passwörter stimmen nicht überein"
+  },
+  "stats": {
+    "bans": "{count, plural, one {Bann} other {Banns}}",
+    "mutes": "{count, plural, one {Stummschaltung} other {Stummschaltungen}}",
+    "players": "{count, plural, one {Spieler} other {Spieler}}",
+    "appeals": "{count, plural, one {Einspruch} other {Einsprüche}}"
+  },
+  "tables": {
+    "id": "ID",
+    "type": "Typ",
+    "reason": "Grund",
+    "by": "Von",
+    "at": "Am",
+    "length": "Dauer",
+    "state": "Status",
+    "assigned": "Zugewiesen",
+    "lastUpdated": "Zuletzt aktualisiert",
+    "player": "Spieler",
+    "name": "Name",
+    "email": "E-Mail"
   },
   "widgets": {
     "select": {
@@ -188,6 +614,50 @@
     "languageSwitcher": {
       "label": "Sprache",
       "select": "Sprache auswählen"
+    },
+    "pushNotifications": {
+      "enable": "Push-Benachrichtigungen aktivieren",
+      "disable": "Push-Benachrichtigungen deaktivieren",
+      "ok": "Ok",
+      "blockedTitle": "Push-Benachrichtigungen aktivieren",
+      "blockedIntro": "Dein Browser blockiert Benachrichtigungen von dieser Seite",
+      "blockedSteps": "Befolge diese Schritte zur Aktivierung:",
+      "chrome": "Chrome",
+      "chromeStep1": "Navigiere zu: <path>chrome://settings/content</path>",
+      "chromeStep2": "Scrolle nach unten und klicke auf die Benachrichtigungsleiste",
+      "chromeStep3": "Suche die URL dieser Seite und wähle „Zulassen“",
+      "chromeAndroid": "Chrome für Android",
+      "chromeAndroidStep1": "Wähle das Symbol mit den drei vertikalen Punkten oben rechts",
+      "chromeAndroidStep2": "Wähle „Einstellungen“ aus dem Dropdown-Menü",
+      "chromeAndroidStep3": "Wähle „Website-Einstellungen“",
+      "chromeAndroidStep4": "Wähle „Benachrichtigungen“",
+      "chromeAndroidStep5": "Hier kannst du diese Website auswählen und Benachrichtigungen aktivieren",
+      "firefox": "Firefox",
+      "firefoxStep1": "Navigiere zu: <path>about:preferences#privacy</path>",
+      "firefoxStep2": "Scrolle nach unten zum Bereich Berechtigungen",
+      "firefoxStep3": "Klicke auf die Schaltfläche „Einstellungen“ neben Benachrichtigungen",
+      "firefoxStep4": "Suche die URL dieser Seite und wähle „Zulassen“",
+      "edge": "Microsoft Edge",
+      "edgeStep1": "Wähle die Schaltfläche „...“ oben rechts im Browserfenster",
+      "edgeStep2": "Wähle „Einstellungen“ aus dem Dropdown-Menü",
+      "edgeStep3": "Wähle „Cookies und Websiteberechtigungen“",
+      "edgeStep4": "Wähle „Benachrichtigungen“",
+      "edgeStep5": "Entferne diese Seite aus dem Bereich „Blockieren“",
+      "safari": "Safari",
+      "safariStep1": "Wähle „Safari“ in der Aktionsleiste oben am Bildschirm und wähle „Einstellungen“",
+      "safariStep2": "Klicke auf den Reiter „Websites“ und wähle dann „Benachrichtigungen“ im Menü auf der linken Seite des Einstellungsfensters",
+      "safariStep3": "Suche diese Seite und aktiviere Benachrichtigungen"
+    },
+    "upload": {
+      "addFiles": "Dateien hinzufügen",
+      "addFilesLong": "Einfügen, ablegen oder klicken, um Dateien hinzuzufügen",
+      "remove": "Entfernen",
+      "failed": "Fehlgeschlagen",
+      "uploading": "Wird hochgeladen...",
+      "uploadFailed": "Upload fehlgeschlagen",
+      "imageName": "Bild {index}",
+      "dropImages": "Bilder hier ablegen",
+      "commentPlaceholder": "Füge deinen Kommentar hier hinzu..."
     }
   },
   "components": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -15,7 +15,16 @@
     "no": "No",
     "ok": "OK",
     "siteName": "Ban Management",
-    "version": "Version"
+    "version": "Version",
+    "add": "Add",
+    "none": "None",
+    "all": "All",
+    "warning": "Warning",
+    "test": "Test",
+    "send": "Send",
+    "create": "Create",
+    "comment": "Comment",
+    "permanent": "Permanent"
   },
   "nav": {
     "login": "Login",
@@ -23,12 +32,15 @@
     "language": "Language",
     "home": "Home",
     "openMenu": "Open menu",
+    "closeMenu": "Close menu",
     "admin": "Admin",
     "dashboard": "Dashboard",
     "notifications": "Notifications",
     "account": "Account",
     "profile": "Profile",
-    "viewProfile": "View profile"
+    "viewProfile": "View profile",
+    "settings": "Settings",
+    "return": "Return"
   },
   "footer": {
     "powered": "Powered by"
@@ -41,7 +53,12 @@
     },
     "register": {
       "title": "Register",
-      "subtitle": "Create your account"
+      "subtitle": "Create your account",
+      "documentTitle": "Register | Account",
+      "feature1": "Login anyplace, anywhere, anytime",
+      "feature2": "Track all punishments including reports",
+      "feature3": "Notifications on appeal updates",
+      "skip": "Skip"
     },
     "forgottenPassword": {
       "title": "Forgotten Password",
@@ -51,9 +68,23 @@
       "title": "Create Appeal",
       "subtitle": "Submit a punishment appeal",
       "documentTitle": "Appeal",
+      "punishmentDocumentTitle": "Select Punishment | Appeal",
+      "pinLoginDocument": "Login | Appeal",
+      "accountLoginDocument": "Login | Appeal",
+      "accountLogin": "Account Login",
+      "appealBan": "Appeal Ban",
+      "appealMute": "Appeal Mute",
+      "appealWarning": "Appeal Warning",
+      "appealBanDocument": "Appeal Ban | Appeal",
+      "appealMuteDocument": "Appeal Mute | Appeal",
+      "appealWarningDocument": "Appeal Warning | Appeal",
+      "punishmentNotFound": "Punishment not found",
+      "headBack": "Head back to the previous page",
       "stepHeader": {
         "step1": "Pin Login",
-        "selectPunishment": "Select Punishment"
+        "selectPunishment": "Select Punishment",
+        "writeAppeal": "Write Appeal",
+        "awaitReview": "Await Review"
       },
       "intro": "First, we need to know who you are.",
       "pinHelp": "I have a 6 digit pin, e.g. ",
@@ -61,14 +92,61 @@
       "pinExpiry": "Note: this pin expires after 5 minutes.",
       "or": "OR",
       "haveAccount": "I already have an account",
-      "haveAccountDescription": "This is specific for this website and NOT your Microsoft/Mojang credentials."
+      "haveAccountDescription": "This is specific for this website and NOT your Microsoft/Mojang credentials.",
+      "noPunishments": "No punishments founds",
+      "tryChangingFilters": "Try changing your filters",
+      "clearFilters": "Clear filters",
+      "reasonLabel": "Why should this punishment be removed?",
+      "reasonPlaceholder": "Explain why this punishment should be removed..."
     },
     "account": {
       "documentTitle": "Account",
       "subtitle": "Account",
       "register": "Register",
       "email": "Email",
-      "password": "Password"
+      "password": "Password",
+      "changeEmail": "Change Email",
+      "changePassword": "Change Password",
+      "changeEmailDocumentTitle": "Change Email | Account",
+      "changePasswordDocumentTitle": "Change Password | Account",
+      "newEmail": "New email address",
+      "newPassword": "New password",
+      "confirmNewPassword": "Confirm new password",
+      "passwordHint": "Must be at least 6 characters long"
+    },
+    "home": {
+      "documentTitle": "Welcome",
+      "appeal": {
+        "subtitle": "Help I've been banned",
+        "title": "Appeal",
+        "intro": "If you believe your account has been wrongfully punished, create an appeal justifying why including any relevant evidence.",
+        "warning": "There is no guarantee your appeal will be successful.",
+        "cta": "Create Appeal"
+      },
+      "search": {
+        "subtitle": "Find a player",
+        "title": "Search",
+        "intro": "Check the full punishment history of a player, including current bans, mutes and more!",
+        "placeholder": "Enter player name"
+      },
+      "account": {
+        "signInTitle": "Sign In",
+        "signInSubtitle": "Already have an account?",
+        "myAccountSubtitle": "My Account",
+        "dashboardCta": "My Dashboard"
+      }
+    },
+    "dashboard": {
+      "title": "Dashboard",
+      "documentTitle": "Dashboard",
+      "appealsDocumentTitle": "Appeals | Dashboard",
+      "reportsDocumentTitle": "Reports | Dashboard",
+      "activePunishments": "Active Punishments",
+      "yourAppeals": "Your appeals",
+      "yourReports": "Your reports",
+      "appeals": "Appeals",
+      "reports": "Reports",
+      "viewAll": "View All"
     },
     "notFound": {
       "title": "Oops! Page Not Found",
@@ -87,15 +165,338 @@
       "intro": "We're sorry, something went wrong on our end. Please try again later.",
       "documentTitle": "Server Error"
     },
+    "notifications": {
+      "title": "Notifications",
+      "documentTitle": "Notifications",
+      "empty": "Nothing to see here yet"
+    },
+    "appeals": {
+      "documentTitle": "#{id} | {name} | {reason} | Appeal",
+      "appealingSentence": "<actor>{actorName}</actor> is appealing a {kind, select, permanent {permanent <badge></badge> issued on {issuedDate} by <punisher>{punisherName}</punisher>} other {temporary <badge></badge> issued on {issuedDate} by <punisher>{punisherName}</punisher> which expires {expiresTime}}}",
+      "commentedAt": "<actor>{actorName}</actor> commented <time>{relative}</time>",
+      "deleteCommentTitle": "Delete comment",
+      "deleteCommentConfirm": "Are you sure you want to delete this comment?",
+      "updates": {
+        "reasonChanged": "<actor>{actorName}</actor> changed the reason from <old>{oldReason}</old> to <new>{newReason}</new>",
+        "expirationChanged": "<actor>{actorName}</actor> modified the expiration from <old>{oldExpires}</old> to <new>{newExpires}</new>",
+        "softChanged": "<actor>{actorName}</actor> set <old>{oldSoft}</old> to <new>{newSoft}</new>",
+        "stateMarked": "<actor>{actorName}</actor> marked this appeal as {state} {time}",
+        "shadow": "shadow",
+        "notShadow": "not shadow",
+        "permanent": "permanent"
+      },
+      "sidebar": {
+        "state": "State",
+        "assignee": "Assignee",
+        "unassigned": "Unassigned",
+        "notifications": "Notifications",
+        "documents": "Documents",
+        "actions": "Actions"
+      },
+      "actions": {
+        "editBan": "Edit Ban",
+        "editMute": "Edit Mute",
+        "editWarning": "Edit Warning",
+        "unban": "Unban",
+        "unmute": "Unmute",
+        "deleteWarning": "Delete warning"
+      },
+      "editTitle": {
+        "ban": "Edit ban",
+        "mute": "Edit mute",
+        "warning": "Edit warning"
+      },
+      "removeTitle": {
+        "ban": "Remove ban",
+        "mute": "Remove mute",
+        "warning": "Remove warning"
+      },
+      "removeConfirm": {
+        "ban": "Are you sure you want to remove this ban?",
+        "mute": "Are you sure you want to remove this mute?",
+        "warning": "Are you sure you want to remove this warning?"
+      }
+    },
+    "report": {
+      "serverLogs": "Server Logs",
+      "close": "Close",
+      "reportRecords": "{count, plural, one {This report has 1 record associated with it} other {This report has # records associated with it}}",
+      "reviewLogs": "Review Logs",
+      "locations": "Locations",
+      "documentTitle": "#{id} | {name} | {reason} | Report",
+      "reportedSentence": "<actor>{actorName}</actor> reported <player>{playerName}</player> on {date}"
+    },
+      "player": {
+            "statistics": {
+                "bans": "Bans",
+                "mutes": "Mutes",
+                "warnings": "Warnings"
+            },
+            "actions": {
+                "ban": "Ban",
+                "mute": "Mute",
+                "warning": "Warn",
+                "note": "Note"
+            },
+            "activeBans": "{total, plural, one {Active Ban (1)} other {Active Bans (#)}}",
+            "activeMutes": "{total, plural, one {Active Mute (1)} other {Active Mutes (#)}}",
+            "pastBans": "{total, plural, one {Past Ban (1)} other {Past Bans (#)}}",
+            "pastMutes": "{total, plural, one {Past Mute (1)} other {Past Mutes (#)}}",
+            "warnings": "{total, plural, one {Warning (1)} other {Warnings (#)}}",
+            "notes": "{total, plural, one {Note (1)} other {Notes (#)}}",
+            "addNote": "Add Note",
+            "kicks": "{total, plural, one {Kick (1)} other {Kicks (#)}}",
+            "pastKicks": "{total, plural, one {Past Kick (1)} other {Past Kicks (#)}}",
+            "alts": "Alts",
+            "history": "History",
+            "playerHistory": "Player History",
+            "noHistory": "No history",
+            "missingDataLine": "If you're missing data here, ensure <docs>logIps</docs> is enabled in the plugin's config.yml file",
+            "close": "Close",
+            "lastSeen": "Last seen {time}",
+            "neverSeen": "Never seen",
+            "actionTitles": {
+              "ban": "Ban {name}",
+              "mute": "Mute {name}",
+              "warn": "Warn {name}",
+              "note": "Note for {name}",
+              "addNoteHeader": "Add note",
+              "addNoteDocument": "Add note to {name}",
+              "editBan": "Edit ban",
+              "editMute": "Edit mute",
+              "editWarning": "Edit warning",
+              "editNote": "Edit note",
+              "editKick": "Edit kick",
+              "editBanDocument": "Edit {name} ban",
+              "editMuteDocument": "Edit {name} mute",
+              "editWarningDocument": "Edit {name} warning",
+              "editNoteDocument": "Edit {name} note"
+            }
+      },
+    "punishment": {
+      "appeal": "Appeal",
+      "read": "Read",
+      "deleteTitle": {
+        "ban": "Delete ban",
+        "mute": "Delete mute",
+        "warning": "Delete warning",
+        "note": "Delete note",
+        "kick": "Delete kick"
+      },
+      "deleteConfirm": {
+        "ban": "Are you sure you want to delete this ban?",
+        "mute": "Are you sure you want to delete this mute?",
+        "warning": "Are you sure you want to delete this warning?",
+        "note": "Are you sure you want to delete this note?",
+        "kick": "Are you sure you want to delete this kick?"
+      },
+      "actionUndoable": "This action cannot be undone",
+      "deletionReasonUnknown": "Deletion reason unknown"
+    },
     "admin": {
       "title": "Admin",
+      "loading": "Loading…",
       "developerMode": "Developer Mode",
       "developerModeMessage": "You are currently running in development mode, expect performance degradation",
       "updateAvailable": "Update Available",
       "currentVersion": "Current version: {current}",
       "latestVersion": "Latest: {latest}",
       "newFeatures": "New Features",
-      "fixes": "Fixes"
+      "fixes": "Fixes",
+      "nav": {
+        "documents": "Documents",
+        "roles": "Roles",
+        "servers": "Servers",
+        "notificationRules": "Notification Rules",
+        "webhooks": "Webhooks"
+      },
+      "documents": {
+        "title": "Documents",
+        "uploadedCount": "{total, plural, one {# document uploaded} other {# documents uploaded}}",
+        "emptyTitle": "No documents uploaded",
+        "emptySubtitle": "Documents attached to appeals and reports will appear here",
+        "document": "Document",
+        "uploadedBy": "Uploaded By",
+        "usedIn": "Used In",
+        "date": "Date",
+        "actions": "Actions",
+        "unknown": "Unknown",
+        "notAttached": "Not attached",
+        "viewFullSize": "View full size",
+        "openInNewTab": "Open in new tab",
+        "deleteTitle": "Delete Document",
+        "deleteConfirm": "Are you sure you want to delete this document?",
+        "deleteWarning": "This action cannot be undone and will remove the image from any appeals it was attached to.",
+        "deleteImage": "Delete image",
+        "deleteImageTitle": "Delete Image",
+        "deleteImageConfirm": "Are you sure you want to delete this image?"
+      },
+      "servers": {
+        "title": "Servers",
+        "server": "Server",
+        "addServer": "Add Server",
+        "editServer": "Edit Server",
+        "editTitle": "Edit {name}",
+        "viewDocumentTitle": "{name} | Server",
+        "stats": {
+          "bans": "Bans",
+          "mutes": "Mutes",
+          "warnings": "Warnings",
+          "reports": "Reports",
+          "total": "Total",
+          "averageLength": "avg length",
+          "averageResolution": "avg resolution",
+          "lastDays": "Last {days} days"
+        },
+        "playerActivity": {
+          "title": "Player Activity",
+          "newJoins": "New Joins",
+          "uniquePlayers": "Unique Players",
+          "summaryTitle": "Activity Summary",
+          "filters": "Filters",
+          "startDate": "Start Date",
+          "endDate": "End Date",
+          "actor": "Actor",
+          "clear": "Clear",
+          "limitWarning": "Results are limited, use the filters to see more",
+          "for": "for",
+          "actions": {
+            "BAN": "Banned",
+            "IPBAN": "Banned {ip}",
+            "UNBAN": "Unbanned",
+            "UNBANIP": "Unbanned {ip}",
+            "IPRANGEBAN": "Banned {fromIp} - {toIp}",
+            "IPRANGEUNBAN": "Unbanned {fromIp} - {toIp}",
+            "MUTE": "Muted",
+            "IPMUTE": "Muted {ip}",
+            "UNMUTE": "Unmuted",
+            "IPUNMUTE": "Unmuted {ip}",
+            "WARNING": "Warned",
+            "NOTE": "Created a note for"
+          }
+        },
+        "deleteTitle": "Delete server",
+        "deleteWarning": "Related <strong>appeals and roles</strong> will be removed",
+        "deleteConfirmInstruction": "Please type <strong>{name}</strong> to confirm",
+        "deletePlaceholder": "Type server name",
+        "form": {
+          "info": "Info",
+          "name": "Name",
+          "consoleUuid": "Console UUID (BanManager/console.yml)",
+          "yamlPlaceholder": "Paste YAML BanManager/config.yml (Optional)",
+          "database": "Database",
+          "host": "Host",
+          "port": "Port",
+          "databaseName": "Database Name",
+          "user": "User",
+          "password": "Password",
+          "databaseTables": "Database Tables"
+        }
+      },
+      "roles": {
+        "title": "Roles",
+        "addRole": "Add Role",
+        "editRole": "Edit Role",
+        "editTitle": "Edit {name}",
+        "deleteTitle": "Delete role",
+        "deleteConfirm": "Are you sure you want to delete this role?",
+        "defaultUnauthenticated": "Assigned by default to all non-logged in visitors",
+        "defaultAuthenticated": "Assigned by default for all logged in players",
+        "superAdmin": "Super admin role with all permissions",
+        "tipsHeader": "Tips",
+        "tip1": "There are 3 default roles which are automatically assigned, these permissions can be modified",
+        "tip2": "Create and assign new roles to grant your moderators permissions to manage appeals, reports etc.",
+        "tip3": "A player can have multiple roles and these are additive, i.e. a permission granted is always given, roles cannot remove a permission granted by another role",
+        "tip4": "Custom roles must define a parent role; when new resources and/or permissions are added to the default roles in an update, they are automatically granted to children roles",
+        "assignGlobal": "Assign Global Player Roles",
+        "assignGlobalHint": "Takes priority over server roles, and applies globally",
+        "assignServer": "Assign Server Player Roles",
+        "assignServerHint": "Only affects certain actions where a server is applicable, e.g. bans",
+        "role": "Role",
+        "assign": "Assign",
+        "form": {
+          "edit": "Edit Role",
+          "name": "Name",
+          "resources": "Resources",
+          "fullAccess": "{name} has access to all resources"
+        }
+      },
+      "notificationRules": {
+        "title": "Notification Rules",
+        "addRule": "Add Rule",
+        "createRule": "Create a rule",
+        "editTitle": "Edit notification rule #{id}",
+        "editTitleHeader": "Edit Notification Rule",
+        "emptyTitle": "There's nothing here",
+        "emptySubtitle": "Notification rules will appear here, try creating one!",
+        "deleteTitle": "Delete notification rule",
+        "deleteConfirm": "Are you sure you want to delete this notification rule?",
+        "form": {
+          "type": "Notification Type",
+          "roles": "Roles",
+          "serverOptional": "Server (optional)",
+          "server": "Server"
+        }
+      },
+      "players": {
+        "globalRoles": "Global Roles",
+        "serverRoles": "Server Roles",
+        "edit": "Edit"
+      },
+      "webhooks": {
+        "title": "Webhooks",
+        "addWebhook": "Add Webhook",
+        "addAWebhook": "Add a webhook",
+        "addWebhookType": "Add {type} Webhook",
+        "editTitle": "Edit Webhook",
+        "editTitleDoc": "Edit Webhook #{id}",
+        "deliveries": "Deliveries",
+        "deliveriesTitle": "Webhook Deliveries",
+        "deliveriesDocumentTitle": "Webhook #{id} Deliveries",
+        "deliveriesEmptyTitle": "No webhook deliveries",
+        "deliveriesEmptySubtitle": "Webhook deliveries will appear here once the webhook has been triggered.",
+        "delivery": {
+          "request": "Request",
+          "response": "Response",
+          "headers": "Headers",
+          "payload": "Payload",
+          "body": "Body",
+          "error": "Error"
+        },
+        "test": {
+          "errorPrefix": "Error sending webhook",
+          "content": "Content"
+        },
+        "selectType": "Select webhook type",
+        "discord": "Discord",
+        "custom": "Custom",
+        "invalidType": "Invalid webhook type",
+        "invalidJson": "Invalid JSON",
+        "emptyTitle": "There's nothing here",
+        "emptySubtitle": "Webhooks allow external services to be notified when an event occurs",
+        "deleteTitle": "Delete webhook",
+        "deleteConfirm": "Are you sure you want to delete this webhook?",
+        "testTitle": "Test webhook",
+        "form": {
+          "eventType": "Event Type",
+          "serverOptional": "Server (optional)",
+          "server": "Server",
+          "url": "URL",
+          "urlPlaceholderCustom": "https://example.com/webhook",
+          "urlPlaceholderDiscord": "https://discord.com/webhook",
+          "contentTemplate": "Content Template",
+          "contentHint": "Use the variables defined to customize the content",
+          "contentPlaceholder": "{exampleJson}",
+          "availableVariables": "Available Variables",
+          "preview": "Preview"
+        }
+      },
+      "layout": {
+        "viewProfile": "View Profile",
+        "settings": "Settings",
+        "notifications": "Notifications",
+        "return": "Return"
+      }
     }
   },
   "errors": {
@@ -103,6 +504,7 @@
     "fetchHeader": "Fetch Error",
     "httpHeader": "HTTP error: {status}",
     "invalidJson": "Invalid JSON",
+    "somethingWentWrong": "Something went wrong",
     "INTERNAL": "Internal Server Error",
     "UNKNOWN": "An unknown error occurred",
     "NO_PERMISSION": "You do not have permission to perform this action",
@@ -171,12 +573,36 @@
     "name": "Name",
     "reason": "Reason",
     "message": "Message",
+    "points": "Points",
+    "soft": "Soft",
+    "softDescription": "Hides their messages to others to prevent spam",
     "comment": "Add your comment here...",
+    "commentPlaceholder": "Add your comment here...",
     "playerSelectorPlaceholder": "Search player",
     "required": "This field is required",
     "minLength": "Must be at least {n} characters",
     "maxLength": "Must be at most {n} characters",
     "passwordMismatch": "Passwords do not match"
+  },
+  "stats": {
+    "bans": "{count, plural, one {Ban} other {Bans}}",
+    "mutes": "{count, plural, one {Mute} other {Mutes}}",
+    "players": "{count, plural, one {Player} other {Players}}",
+    "appeals": "{count, plural, one {Appeal} other {Appeals}}"
+  },
+  "tables": {
+    "id": "ID",
+    "type": "Type",
+    "reason": "Reason",
+    "by": "By",
+    "at": "At",
+    "length": "Length",
+    "state": "State",
+    "assigned": "Assigned",
+    "lastUpdated": "Last Updated",
+    "player": "Player",
+    "name": "Name",
+    "email": "Email"
   },
   "widgets": {
     "select": {
@@ -188,6 +614,50 @@
     "languageSwitcher": {
       "label": "Language",
       "select": "Select language"
+    },
+    "pushNotifications": {
+      "enable": "Enable push notifications",
+      "disable": "Disable push notifications",
+      "ok": "Ok",
+      "blockedTitle": "Enable Push Notifications",
+      "blockedIntro": "Your browser is blocking notifications from this site",
+      "blockedSteps": "Follow these steps to enable:",
+      "chrome": "Chrome",
+      "chromeStep1": "Navigate to: <path>chrome://settings/content</path>",
+      "chromeStep2": "Scroll down and click on the Notifications bar",
+      "chromeStep3": "Find the URL of this site select allow",
+      "chromeAndroid": "Chrome for Android",
+      "chromeAndroidStep1": "Select the vertical elipses icon in the top-right corner of the screen",
+      "chromeAndroidStep2": "Select the “Settings” option from the dropdown menu",
+      "chromeAndroidStep3": "Select the “Site settings” option",
+      "chromeAndroidStep4": "Select the “Notifications” option",
+      "chromeAndroidStep5": "Here you can select this website and enable notifications",
+      "firefox": "Firefox",
+      "firefoxStep1": "Navigate to: <path>about:preferences#privacy</path>",
+      "firefoxStep2": "Scroll down to the Permissions section",
+      "firefoxStep3": "Click the Settings button next to Notifications",
+      "firefoxStep4": "Find the URL of this site and select Allow",
+      "edge": "Microsoft Edge",
+      "edgeStep1": "Select the “...” button in the top-right corner of the browser window",
+      "edgeStep2": "Select the “Settings” option from the dropdown menu",
+      "edgeStep3": "Select the “Cookies and site permissions” option",
+      "edgeStep4": "Select the “Notifications” option",
+      "edgeStep5": "Remove this site from the “Block“ section",
+      "safari": "Safari",
+      "safariStep1": "Select “Safari” in the action bar at the top of the screen and select “Preferences”",
+      "safariStep2": "Click on the “Websites” tab and then select “Notifications” in the menu on the left-side of the preferences window",
+      "safariStep3": "Find this site and enable notifications"
+    },
+    "upload": {
+      "addFiles": "Add files",
+      "addFilesLong": "Paste, drop, or click to add files",
+      "remove": "Remove",
+      "failed": "Failed",
+      "uploading": "Uploading...",
+      "uploadFailed": "Upload failed",
+      "imageName": "Image {index}",
+      "dropImages": "Drop images here",
+      "commentPlaceholder": "Add your comment here..."
     }
   },
   "components": {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react'
 
 import '../styles/index.css'
 import enMessages from '../messages/en.json'
-import { DEFAULT_LOCALE, LOCALE_CONFIG, useResolvedLocale } from '../utils/locale'
+import { DEFAULT_LOCALE, LOCALE_CONFIG, LocaleProvider, useResolvedLocale } from '../utils/locale'
 
 const PRELOADED_MESSAGES = { en: enMessages }
 const isDev = process.env.NODE_ENV !== 'production'
@@ -58,7 +58,7 @@ const intlGetMessageFallback = ({ key, namespace }) => {
   return isDev ? `[${fullKey}]` : ''
 }
 
-function MyApp ({ Component, pageProps }) {
+function I18nShell ({ Component, pageProps }) {
   const { locale } = useResolvedLocale()
   const [messages, setMessages] = useState(enMessages)
   const [activeLocale, setActiveLocale] = useState(DEFAULT_LOCALE)
@@ -137,6 +137,14 @@ function MyApp ({ Component, pageProps }) {
       />
       <Component {...pageProps} />
     </NextIntlClientProvider>
+  )
+}
+
+function MyApp (props) {
+  return (
+    <LocaleProvider>
+      <I18nShell {...props} />
+    </LocaleProvider>
   )
 }
 

--- a/pages/account/email.js
+++ b/pages/account/email.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../components/DefaultLayout'
 import PageContainer from '../../components/PageContainer'
 import ResetEmailForm from '../../components/ResetEmailForm'
@@ -6,13 +7,14 @@ import { useUser } from '../../utils'
 import Panel from '../../components/Panel'
 
 export default function Page () {
+  const t = useTranslations()
   const { user } = useUser({ redirectTo: '/login' })
 
   return (
-    <DefaultLayout title='Change Email | Account' loading={!user}>
+    <DefaultLayout title={t('pages.account.changeEmailDocumentTitle')} loading={!user}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader title='Change Email' subTitle='Account' />
+          <PageHeader title={t('pages.account.changeEmail')} subTitle={t('pages.account.subtitle')} />
           <ResetEmailForm />
         </Panel>
       </PageContainer>

--- a/pages/account/password.js
+++ b/pages/account/password.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../components/DefaultLayout'
 import PageContainer from '../../components/PageContainer'
 import ResetPasswordForm from '../../components/ResetPasswordForm'
@@ -6,13 +7,14 @@ import { useUser } from '../../utils'
 import Panel from '../../components/Panel'
 
 export default function Page () {
+  const t = useTranslations()
   const { user } = useUser({ redirectTo: '/login' })
 
   return (
-    <DefaultLayout title='Change Password | Account' loading={!user}>
+    <DefaultLayout title={t('pages.account.changePasswordDocumentTitle')} loading={!user}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader title='Change Password' subTitle='Account' />
+          <PageHeader title={t('pages.account.changePassword')} subTitle={t('pages.account.subtitle')} />
           <ResetPasswordForm showCurrentPassword={user?.type === 'password'} />
         </Panel>
       </PageContainer>

--- a/pages/account/register.js
+++ b/pages/account/register.js
@@ -5,12 +5,14 @@ import PageHeader from '../../components/PageHeader'
 import { useUser } from '../../utils'
 import { useEffect } from 'react'
 import { TiTick } from 'react-icons/ti'
+import { useTranslations } from 'next-intl'
 import Panel from '../../components/Panel'
 import Button from '../../components/Button'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
 export default function Page () {
+  const t = useTranslations('pages.register')
   const router = useRouter()
   const { user } = useUser({ redirectTo: '/login', redirectIfFound: false })
 
@@ -21,21 +23,21 @@ export default function Page () {
   }, [user])
 
   return (
-    <DefaultLayout title='Register | Account' loading={!user}>
+    <DefaultLayout title={t('documentTitle')} loading={!user}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader title='Register' subTitle='Create an account' />
+          <PageHeader title={t('title')} subTitle={t('subtitle')} />
           <div className='bg-primary-900 rounded-3xl grid grid-cols-12 p-2 gap-4 items-center mb-2'>
             <div className='col-span-1'><TiTick /></div>
-            <div className='col-span-11'>Login anyplace, anywhere, anytime</div>
+            <div className='col-span-11'>{t('feature1')}</div>
             <div className='col-span-1'><TiTick /></div>
-            <div className='col-span-11'>Track all punishments including reports</div>
+            <div className='col-span-11'>{t('feature2')}</div>
             <div className='col-span-1'><TiTick /></div>
-            <div className='col-span-11'>Notifications on appeal updates</div>
+            <div className='col-span-11'>{t('feature3')}</div>
           </div>
           <Link href='/dashboard'>
             <Button className='bg-black mb-6' data-cy='submit-register-skip'>
-              Skip
+              {t('skip')}
             </Button>
           </Link>
           <PlayerRegisterForm />

--- a/pages/admin/documents.js
+++ b/pages/admin/documents.js
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslations } from 'next-intl'
 import Loader from '../../components/Loader'
 import ErrorLayout from '../../components/ErrorLayout'
 import AdminLayout from '../../components/AdminLayout'
@@ -12,6 +13,7 @@ import { FiImage } from 'react-icons/fi'
 const LIMIT = 25
 
 export default function Page () {
+  const t = useTranslations()
   const [tableState, setTableState] = useState({ offset: 0, player: null, dateStart: null, dateEnd: null })
   const { loading, data, errors, mutate } = useApi({
     query: `query listDocuments($limit: Int, $offset: Int, $player: UUID, $dateStart: Timestamp, $dateEnd: Timestamp) {
@@ -54,7 +56,7 @@ export default function Page () {
     mutate({ ...data, listDocuments: { ...data.listDocuments, total: data.listDocuments.total - 1, records } }, false)
   }
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const total = data?.listDocuments?.total || 0
@@ -63,10 +65,10 @@ export default function Page () {
   const currentPage = Math.floor(tableState.offset / LIMIT) + 1
 
   return (
-    <AdminLayout title='Documents'>
-      <AdminHeader title='Documents'>
+    <AdminLayout title={t('pages.admin.documents.title')}>
+      <AdminHeader title={t('pages.admin.documents.title')}>
         <div className='text-gray-400 text-sm'>
-          {total} document{total === 1 ? '' : 's'} uploaded
+          {t('pages.admin.documents.uploadedCount', { total })}
         </div>
       </AdminHeader>
       <div className='lg:col-span-3'>
@@ -87,8 +89,8 @@ export default function Page () {
             )
           : (
             <EmptyState
-              title='No documents uploaded'
-              subTitle='Documents attached to appeals and reports will appear here'
+              title={t('pages.admin.documents.emptyTitle')}
+              subTitle={t('pages.admin.documents.emptySubtitle')}
             >
               <FiImage className='w-12 h-12 text-gray-500 mx-auto' />
             </EmptyState>

--- a/pages/admin/notification-rules/[id]/index.js
+++ b/pages/admin/notification-rules/[id]/index.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import AdminLayout from '../../../../components/AdminLayout'
 import ErrorLayout from '../../../../components/ErrorLayout'
 import Loader from '../../../../components/Loader'
@@ -7,6 +8,7 @@ import PageHeader from '../../../../components/admin/AdminHeader'
 import NotificationRuleForm from '../../../../components/admin/notification-rules/NotificationRuleForm'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const invalidate = useInvalidateApiCache()
   const { id } = router.query
@@ -39,7 +41,7 @@ export default function Page () {
     }`
   })
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const query = `mutation updateNotificationRule($id: ID!, $input: NotificationRuleInput!) {
@@ -58,8 +60,8 @@ export default function Page () {
   const notificationTypes = data.__type.enumValues.map(type => ({ value: type.name, label: type.name }))
 
   return (
-    <AdminLayout title={`Edit notification rule #${data.notificationRule.id}`}>
-      <PageHeader title='Edit Notification Rule' />
+    <AdminLayout title={t('pages.admin.notificationRules.editTitle', { id: data.notificationRule.id })}>
+      <PageHeader title={t('pages.admin.notificationRules.editTitleHeader')} />
       <div className='mx-auto flex flex-col max-w-md'>
         <NotificationRuleForm
           defaults={data.notificationRule}

--- a/pages/admin/notification-rules/add.js
+++ b/pages/admin/notification-rules/add.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import Loader from '../../../components/Loader'
 import AdminLayout from '../../../components/AdminLayout'
 import ErrorLayout from '../../../components/ErrorLayout'
@@ -7,6 +8,7 @@ import { useApi, useInvalidateApiCache } from '../../../utils'
 import NotificationRuleForm from '../../../components/admin/notification-rules/NotificationRuleForm'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const invalidate = useInvalidateApiCache()
   const { loading, data, errors } = useApi({
@@ -23,7 +25,7 @@ export default function Page () {
     }`
   })
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const query = ` mutation createNotificationRule($input: NotificationRuleInput!) {
@@ -35,8 +37,8 @@ export default function Page () {
   const notificationTypes = data.__type.enumValues.map(type => ({ value: type.name, label: type.name }))
 
   return (
-    <AdminLayout title='Add Notification Rule'>
-      <PageHeader title='Add Notification Rule' />
+    <AdminLayout title={t('pages.admin.notificationRules.addRule')}>
+      <PageHeader title={t('pages.admin.notificationRules.addRule')} />
       <div className='mx-auto flex flex-col max-w-md'>
         <NotificationRuleForm
           query={query}

--- a/pages/admin/notification-rules/index.js
+++ b/pages/admin/notification-rules/index.js
@@ -1,5 +1,6 @@
 import { AiOutlinePlus } from 'react-icons/ai'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import Loader from '../../../components/Loader'
 import ErrorLayout from '../../../components/ErrorLayout'
 import AdminLayout from '../../../components/AdminLayout'
@@ -10,6 +11,7 @@ import NotificationRuleItem from '../../../components/admin/notification-rules/N
 import EmptyState from '../../../components/EmptyState'
 
 export default function Page () {
+  const t = useTranslations()
   const { loading, data, errors, mutate } = useApi({
     query: `query {
       listNotificationRules {
@@ -36,18 +38,18 @@ export default function Page () {
     mutate({ ...data, listNotificationRules: { records: rules } }, false)
   }
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const items = data?.listNotificationRules?.records?.map(row => <NotificationRuleItem key={row.id} row={row} onDeleted={onDeleted} />)
 
   return (
-    <AdminLayout title='Notification Rules'>
-      <AdminHeader title='Notification Rules'>
+    <AdminLayout title={t('pages.admin.notificationRules.title')}>
+      <AdminHeader title={t('pages.admin.notificationRules.title')}>
         <div>
           <Link href='/admin/notification-rules/add' passHref>
 
-            <Button className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><AiOutlinePlus className='text-xl -ml-1 mr-2' /> Add Rule</Button>
+            <Button className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><AiOutlinePlus className='text-xl -ml-1 mr-2' /> {t('pages.admin.notificationRules.addRule')}</Button>
 
           </Link>
         </div>
@@ -57,10 +59,10 @@ export default function Page () {
         {items.length
           ? items
           : (
-            <EmptyState title={'There\'s nothing here'} subTitle='Notification rules will appear here, try creating one!'>
+            <EmptyState title={t('pages.admin.notificationRules.emptyTitle')} subTitle={t('pages.admin.notificationRules.emptySubtitle')}>
               <Link href='/admin/notification-rules/add' passHref>
 
-                <Button className='w-44 bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><AiOutlinePlus className='text-xl -ml-1 mr-2' /> Create a rule</Button>
+                <Button className='w-44 bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><AiOutlinePlus className='text-xl -ml-1 mr-2' /> {t('pages.admin.notificationRules.createRule')}</Button>
 
               </Link>
             </EmptyState>

--- a/pages/admin/roles/[id].js
+++ b/pages/admin/roles/[id].js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import Loader from '../../../components/Loader'
 import AdminLayout from '../../../components/AdminLayout'
 import ErrorLayout from '../../../components/ErrorLayout'
@@ -6,6 +7,7 @@ import { useApi, useInvalidateApiCache } from '../../../utils'
 import RoleForm from '../../../components/admin/RoleForm'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const invalidate = useInvalidateApiCache()
   const { id } = router.query
@@ -35,7 +37,7 @@ export default function Page () {
     }`
   })
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const query = `mutation updateRole($id: ID!, $input: UpdateRoleInput!) {
@@ -57,7 +59,7 @@ export default function Page () {
   const parentRoles = data.roles.map(role => ({ value: role.id, label: role.name }))
 
   return (
-    <AdminLayout title={`Edit ${data.role.name}`}>
+    <AdminLayout title={t('pages.admin.roles.editTitle', { name: data.role.name })}>
       <RoleForm
         defaults={data.role}
         query={query}

--- a/pages/admin/roles/add.js
+++ b/pages/admin/roles/add.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import Loader from '../../../components/Loader'
 import AdminLayout from '../../../components/AdminLayout'
 import ErrorLayout from '../../../components/ErrorLayout'
@@ -6,6 +7,7 @@ import { useApi, useInvalidateApiCache } from '../../../utils'
 import RoleForm from '../../../components/admin/RoleForm'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const invalidate = useInvalidateApiCache()
   const { loading, data, errors } = useApi({
@@ -26,7 +28,7 @@ export default function Page () {
     }`
   })
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const query = `mutation createRole($input: UpdateRoleInput!) {
@@ -37,7 +39,7 @@ export default function Page () {
   const parentRoles = data.roles.map(role => ({ value: role.id, label: role.name }))
 
   return (
-    <AdminLayout title='Add Role'>
+    <AdminLayout title={t('pages.admin.roles.addRole')}>
       <RoleForm
         query={query}
         parentRoles={parentRoles}

--- a/pages/admin/roles/index.js
+++ b/pages/admin/roles/index.js
@@ -1,5 +1,6 @@
 import { AiOutlinePlus } from 'react-icons/ai'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import Loader from '../../../components/Loader'
 import ErrorLayout from '../../../components/ErrorLayout'
 import AdminLayout from '../../../components/AdminLayout'
@@ -12,6 +13,7 @@ import { useApi } from '../../../utils'
 import Message from '../../../components/Message'
 
 export default function Page () {
+  const t = useTranslations()
   const { loading, data, errors, mutate } = useApi({
     query: `query rolesAdminPage {
       roles {
@@ -30,7 +32,7 @@ export default function Page () {
     mutate({ ...data, roles }, false)
   }
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const items = data.roles.map(role => <RoleItem key={role.id} role={role} onDeleted={onDeleted} />)
@@ -46,12 +48,12 @@ export default function Page () {
   }`
 
   return (
-    <AdminLayout title='Roles'>
-      <PageHeader title='Roles' />
+    <AdminLayout title={t('pages.admin.roles.title')}>
+      <PageHeader title={t('pages.admin.roles.title')} />
       <div className='w-24 mb-5'>
         <Link href='/admin/roles/add' passHref>
 
-          <Button className='bg-emerald-600 hover:bg-emerald-700'><AiOutlinePlus className='text-xl' /> Add</Button>
+          <Button className='bg-emerald-600 hover:bg-emerald-700'><AiOutlinePlus className='text-xl' /> {t('common.add')}</Button>
 
         </Link>
       </div>
@@ -61,23 +63,23 @@ export default function Page () {
       <div className='grid grid-cols-1 md:grid-cols-3 gap-6 mb-12 justify-items-center'>
         <div>
           <Message info>
-            <Message.Header>Tips</Message.Header>
+            <Message.Header>{t('pages.admin.roles.tipsHeader')}</Message.Header>
             <Message.List>
-              <Message.Item>There are 3 default roles which are automatically assigned, these permissions can be modified</Message.Item>
-              <Message.Item>Create and assign new roles to grant your moderators permissions to manage appeals, reports etc.</Message.Item>
-              <Message.Item>A player can have multiple roles and these are additive, i.e. a permission granted is always given, roles cannot remove a permission granted by another role</Message.Item>
-              <Message.Item>Custom roles must define a parent role; when new resources and/or permissions are added to the default roles in an update, they are automatically granted to children roles</Message.Item>
+              <Message.Item>{t('pages.admin.roles.tip1')}</Message.Item>
+              <Message.Item>{t('pages.admin.roles.tip2')}</Message.Item>
+              <Message.Item>{t('pages.admin.roles.tip3')}</Message.Item>
+              <Message.Item>{t('pages.admin.roles.tip4')}</Message.Item>
             </Message.List>
           </Message>
         </div>
         <div data-cy='assign-global-role'>
-          <PageHeader title='Assign Global Player Roles' />
-          <p className='mb-6'>Takes priority over server roles, and applies globally</p>
+          <PageHeader title={t('pages.admin.roles.assignGlobal')} />
+          <p className='mb-6'>{t('pages.admin.roles.assignGlobalHint')}</p>
           <AssignPlayersRoleForm roles={data.roles} query={globalRoleMutation} />
         </div>
         <div data-cy='assign-server-role'>
-          <PageHeader title='Assign Server Player Roles' />
-          <p className='mb-6'>Only affects certain actions where a server is applicable, e.g. bans</p>
+          <PageHeader title={t('pages.admin.roles.assignServer')} />
+          <p className='mb-6'>{t('pages.admin.roles.assignServerHint')}</p>
           <AssignPlayersRoleForm roles={data.roles} servers={data.servers} query={serverRoleMutation} />
         </div>
       </div>

--- a/pages/admin/servers/[id]/edit.js
+++ b/pages/admin/servers/[id]/edit.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import AdminLayout from '../../../../components/AdminLayout'
 import ErrorLayout from '../../../../components/ErrorLayout'
 import Loader from '../../../../components/Loader'
@@ -6,6 +7,7 @@ import { useApi, useInvalidateApiCache } from '../../../../utils'
 import ServerForm from '../../../../components/admin/ServerForm'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const invalidate = useInvalidateApiCache()
   const { id } = router.query
@@ -54,7 +56,7 @@ export default function Page () {
     }`
   })
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const query = `mutation updateServer($id: ID!, $input: UpdateServerInput!) {
@@ -64,7 +66,7 @@ export default function Page () {
   }`
 
   return (
-    <AdminLayout title={`Edit ${data.server.name}`}>
+    <AdminLayout title={t('pages.admin.servers.editTitle', { name: data.server.name })}>
       <ServerForm
         defaults={data.server}
         query={query}

--- a/pages/admin/servers/[id]/index.js
+++ b/pages/admin/servers/[id]/index.js
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import AdminLayout from '../../../../components/AdminLayout'
 import ErrorLayout from '../../../../components/ErrorLayout'
 import Loader from '../../../../components/Loader'
@@ -13,6 +14,7 @@ import ServerWarningStats from '../../../../components/admin/servers/stats/Serve
 import PlayerActivity from '../../../../components/admin/servers/PlayerActivity'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const { id } = router.query
   const { loading, data, errors } = useApi({
@@ -27,16 +29,16 @@ export default function Page () {
     }`
   })
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   return (
-    <AdminLayout title={`Server ${data.server.name}`}>
+    <AdminLayout title={t('pages.admin.servers.viewDocumentTitle', { name: data.server.name })}>
       <AdminHeader title={data.server.name}>
         <div>
           <Link href={`/admin/servers/${data.server.id}/edit`} passHref>
 
-            <Button className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'>Edit Server</Button>
+            <Button className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'>{t('pages.admin.servers.editServer')}</Button>
 
           </Link>
         </div>

--- a/pages/admin/servers/add.js
+++ b/pages/admin/servers/add.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import Loader from '../../../components/Loader'
 import AdminLayout from '../../../components/AdminLayout'
 import ErrorLayout from '../../../components/ErrorLayout'
@@ -7,6 +8,7 @@ import { useApi, useInvalidateApiCache } from '../../../utils'
 import ServerForm from '../../../components/admin/ServerForm'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const invalidate = useInvalidateApiCache()
   const { loading, data, errors } = useApi({
@@ -15,7 +17,7 @@ export default function Page () {
     }`
   })
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const query = ` mutation createServer($input: CreateServerInput!) {
@@ -25,8 +27,8 @@ export default function Page () {
   }`
 
   return (
-    <AdminLayout title='Add Server'>
-      <PageHeader title='Add Server' />
+    <AdminLayout title={t('pages.admin.servers.addServer')}>
+      <PageHeader title={t('pages.admin.servers.addServer')} />
       <ServerForm
         query={query}
         serverTables={data.serverTables}

--- a/pages/admin/servers/index.js
+++ b/pages/admin/servers/index.js
@@ -1,5 +1,6 @@
 import { AiOutlinePlus } from 'react-icons/ai'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import Loader from '../../../components/Loader'
 import ErrorLayout from '../../../components/ErrorLayout'
 import AdminLayout from '../../../components/AdminLayout'
@@ -9,6 +10,7 @@ import { useApi } from '../../../utils'
 import AdminHeader from '../../../components/admin/AdminHeader'
 
 export default function Page () {
+  const t = useTranslations()
   const { loading, data, errors, mutate } = useApi({
     query: `query servers {
       servers {
@@ -29,19 +31,19 @@ export default function Page () {
     mutate({ ...data, servers }, false)
   }
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const canDelete = data.servers.length !== 1
   const items = data.servers.map(server => <ServerItem key={server.id} server={server} canDelete={canDelete} onDeleted={onDeleted} />)
 
   return (
-    <AdminLayout title='Servers'>
-      <AdminHeader title='Servers'>
+    <AdminLayout title={t('pages.admin.servers.title')}>
+      <AdminHeader title={t('pages.admin.servers.title')}>
         <div>
           <Link href='/admin/servers/add' passHref>
 
-            <Button className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><AiOutlinePlus className='text-xl -ml-1 mr-2' /> Add Server</Button>
+            <Button className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><AiOutlinePlus className='text-xl -ml-1 mr-2' /> {t('pages.admin.servers.addServer')}</Button>
 
           </Link>
         </div>

--- a/pages/admin/webhooks/[id]/deliveries.js
+++ b/pages/admin/webhooks/[id]/deliveries.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import AdminLayout from '../../../../components/AdminLayout'
 import ErrorLayout from '../../../../components/ErrorLayout'
 import Loader from '../../../../components/Loader'
@@ -7,6 +8,7 @@ import AdminHeader from '../../../../components/admin/AdminHeader'
 import WebhookDeliveryItem from '../../../../components/admin/webhooks/WebhookDeliveryItem'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const { id } = router.query
   const { loading, data, errors } = useApi({
@@ -27,14 +29,14 @@ export default function Page () {
     }`
   })
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const items = data?.listWebhookDeliveries?.records?.map(row => (<WebhookDeliveryItem key={`delivery-${row.id}`} {...row} />))
 
   return (
-    <AdminLayout title={`Webhook #${id} Deliveries`}>
-      <AdminHeader title='Webhook Deliveries' />
+    <AdminLayout title={t('pages.admin.webhooks.deliveriesDocumentTitle', { id })}>
+      <AdminHeader title={t('pages.admin.webhooks.deliveriesTitle')} />
       <div className='flex flex-col gap-3'>
         {loading && <Loader />}
         {items.length
@@ -42,8 +44,8 @@ export default function Page () {
           : (
             <div className='bg-white shadow overflow-hidden sm:rounded-md'>
               <div className='px-4 py-5 sm:px-6'>
-                <h3 className='text-lg leading-6 font-medium text-gray-900'>No webhook deliveries</h3>
-                <p className='mt-1 max-w-2xl text-sm text-gray-500'>Webhook deliveries will appear here once the webhook has been triggered.</p>
+                <h3 className='text-lg leading-6 font-medium text-gray-900'>{t('pages.admin.webhooks.deliveriesEmptyTitle')}</h3>
+                <p className='mt-1 max-w-2xl text-sm text-gray-500'>{t('pages.admin.webhooks.deliveriesEmptySubtitle')}</p>
               </div>
             </div>
             )}

--- a/pages/admin/webhooks/[id]/index.js
+++ b/pages/admin/webhooks/[id]/index.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import AdminLayout from '../../../../components/AdminLayout'
 import ErrorLayout from '../../../../components/ErrorLayout'
 import Loader from '../../../../components/Loader'
@@ -10,6 +11,7 @@ import Button from '../../../../components/Button'
 import Link from 'next/link'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const invalidate = useInvalidateApiCache()
   const { id } = router.query
@@ -43,7 +45,7 @@ export default function Page () {
     }`
   })
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const query = ` mutation updateWebhook($id: ID!, $input: UpdateWebhookInput!) {
@@ -64,11 +66,11 @@ export default function Page () {
   const webhookContentTypes = data.webhookContentTypes.enumValues.map(type => ({ value: type.name, label: type.name }))
 
   return (
-    <AdminLayout title={`Edit Webhook #${data.webhook.id}`}>
-      <AdminHeader title='Edit Webhook'>
+    <AdminLayout title={t('pages.admin.webhooks.editTitleDoc', { id: data.webhook.id })}>
+      <AdminHeader title={t('pages.admin.webhooks.editTitle')}>
         <div>
           <Link href={`/admin/webhooks/${data.webhook.id}/deliveries`} passHref>
-            <Button className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'>Deliveries</Button>
+            <Button className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'>{t('pages.admin.webhooks.deliveries')}</Button>
           </Link>
         </div>
       </AdminHeader>

--- a/pages/admin/webhooks/add/[type].js
+++ b/pages/admin/webhooks/add/[type].js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import Loader from '../../../../components/Loader'
 import AdminLayout from '../../../../components/AdminLayout'
 import ErrorLayout from '../../../../components/ErrorLayout'
@@ -8,6 +9,7 @@ import WebhookForm from '../../../../components/admin/webhooks/WebhookForm'
 import WebhookDiscordForm from '../../../../components/admin/webhooks/WebhookDiscordForm'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const invalidate = useInvalidateApiCache()
   const { type } = router.query
@@ -26,9 +28,9 @@ export default function Page () {
     }`
   })
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
-  if (type !== 'discord' && type !== 'custom') return <ErrorLayout errors={[{ message: 'Invalid webhook type' }]} />
+  if (type !== 'discord' && type !== 'custom') return <ErrorLayout errors={[{ message: t('pages.admin.webhooks.invalidType') }]} />
 
   const query = ` mutation createWebhook($input: CreateWebhookInput!) {
     createWebhook(input: $input) {
@@ -37,11 +39,12 @@ export default function Page () {
   }`
   const webhookTypes = data.webhookTypes.enumValues.map(type => ({ value: type.name, label: type.name }))
   const webhookContentTypes = data.webhookContentTypes.enumValues.map(type => ({ value: type.name, label: type.name }))
-  const title = type.charAt(0).toUpperCase() + type.slice(1)
+  const title = t(`pages.admin.webhooks.${type}`)
+  const headerTitle = t('pages.admin.webhooks.addWebhookType', { type: title })
 
   return (
-    <AdminLayout title={`Add ${title} Webhook`}>
-      <PageHeader title={`Add ${title} Webhook`} />
+    <AdminLayout title={headerTitle}>
+      <PageHeader title={headerTitle} />
       <div className='flex flex-col'>
         {type === 'discord'
           ? (

--- a/pages/admin/webhooks/add/index.js
+++ b/pages/admin/webhooks/add/index.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import AdminLayout from '../../../../components/AdminLayout'
 import PageHeader from '../../../../components/PageHeader'
 import { FaDiscord } from 'react-icons/fa'
@@ -5,17 +6,18 @@ import { MdSettings } from 'react-icons/md'
 import Link from 'next/link'
 
 export default function Page () {
+  const t = useTranslations()
   return (
-    <AdminLayout title='Add Webhook'>
-      <PageHeader title='Add Webhook' />
+    <AdminLayout title={t('pages.admin.webhooks.addWebhook')}>
+      <PageHeader title={t('pages.admin.webhooks.addWebhook')} />
       <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 mb-6 gap-6 justify-items-center xl:justify-items-stretch'>
         <Link href='/admin/webhooks/add/custom' className='bg-black shadow-md rounded-md overflow-hidden text-center w-60 py-3'>
           <MdSettings className='h-16 w-16 mx-auto mb-8' />
-          Custom
+          {t('pages.admin.webhooks.custom')}
         </Link>
         <Link href='/admin/webhooks/add/discord' className='bg-black shadow-md rounded-md overflow-hidden text-center w-60 py-3'>
           <FaDiscord className='h-16 w-16 mx-auto mb-8' />
-          Discord
+          {t('pages.admin.webhooks.discord')}
         </Link>
       </div>
     </AdminLayout>

--- a/pages/admin/webhooks/index.js
+++ b/pages/admin/webhooks/index.js
@@ -1,5 +1,6 @@
 import { AiOutlinePlus } from 'react-icons/ai'
 import Link from 'next/link'
+import { useTranslations } from 'next-intl'
 import Loader from '../../../components/Loader'
 import ErrorLayout from '../../../components/ErrorLayout'
 import AdminLayout from '../../../components/AdminLayout'
@@ -10,6 +11,7 @@ import WebhookItem from '../../../components/admin/webhooks/WebhookItem'
 import EmptyState from '../../../components/EmptyState'
 
 export default function Page () {
+  const t = useTranslations()
   const { loading, data, errors, mutate } = useApi({
     query: `query {
       listWebhooks {
@@ -35,18 +37,18 @@ export default function Page () {
     mutate({ ...data, listWebhooks: { records: rules } }, false)
   }
 
-  if (loading) return <AdminLayout title='Loading...'><Loader /></AdminLayout>
+  if (loading) return <AdminLayout title={t('pages.admin.loading')}><Loader /></AdminLayout>
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const items = data?.listWebhooks?.records?.map(row => <WebhookItem key={row.id} row={row} onDeleted={onDeleted} />)
 
   return (
-    <AdminLayout title='Webhooks'>
-      <AdminHeader title='Webhooks'>
+    <AdminLayout title={t('pages.admin.webhooks.title')}>
+      <AdminHeader title={t('pages.admin.webhooks.title')}>
         <div>
           <Link href='/admin/webhooks/add' passHref>
 
-            <Button className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><AiOutlinePlus className='text-xl -ml-1 mr-2' /> Add Webhook</Button>
+            <Button className='bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><AiOutlinePlus className='text-xl -ml-1 mr-2' /> {t('pages.admin.webhooks.addWebhook')}</Button>
 
           </Link>
         </div>
@@ -56,10 +58,10 @@ export default function Page () {
         {items.length
           ? items
           : (
-            <EmptyState title={'There\'s nothing here'} subTitle='Webhooks allow external services to be notified when an event occurs'>
+            <EmptyState title={t('pages.admin.webhooks.emptyTitle')} subTitle={t('pages.admin.webhooks.emptySubtitle')}>
               <Link href='/admin/webhooks/add' passHref>
 
-                <Button className='w-44 bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><AiOutlinePlus className='text-xl -ml-1 mr-2' /> Add a webhook</Button>
+                <Button className='w-44 bg-emerald-600 hover:bg-emerald-700 text-sm px-4 py-2'><AiOutlinePlus className='text-xl -ml-1 mr-2' /> {t('pages.admin.webhooks.addAWebhook')}</Button>
 
               </Link>
             </EmptyState>

--- a/pages/appeal/account.js
+++ b/pages/appeal/account.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../components/DefaultLayout'
 import PageContainer from '../../components/PageContainer'
 import PlayerLoginPasswordForm from '../../components/PlayerLoginPasswordForm'
@@ -7,6 +8,7 @@ import Panel from '../../components/Panel'
 import AppealStepHeader from '../../components/appeal/AppealStepHeader'
 
 function Page () {
+  const t = useTranslations('pages.appeal')
   const router = useRouter()
   const { user } = useUser({ redirectIfFound: true, redirectTo: '/appeal/punishment' })
   const onSuccess = () => {
@@ -14,10 +16,10 @@ function Page () {
   }
 
   return (
-    <DefaultLayout title='Login | Appeal' loading={user}>
+    <DefaultLayout title={t('accountLoginDocument')} loading={user}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <AppealStepHeader step={1} title='Account Login' nextStep='Select Punishment' />
+          <AppealStepHeader step={1} title={t('accountLogin')} nextStep={t('stepHeader.selectPunishment')} />
           <PlayerLoginPasswordForm onSuccess={onSuccess} />
         </Panel>
       </PageContainer>

--- a/pages/appeal/pin.js
+++ b/pages/appeal/pin.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../components/DefaultLayout'
 import PageContainer from '../../components/PageContainer'
 import PlayerLoginPinForm from '../../components/PlayerLoginPinForm'
@@ -7,6 +8,7 @@ import Panel from '../../components/Panel'
 import AppealStepHeader from '../../components/appeal/AppealStepHeader'
 
 function Page () {
+  const t = useTranslations('pages.appeal')
   const router = useRouter()
   const { user } = useUser({ redirectIfFound: true, redirectTo: '/appeal/punishment' })
   const onSuccess = () => {
@@ -14,10 +16,10 @@ function Page () {
   }
 
   return (
-    <DefaultLayout title='Login | Appeal' loading={user}>
+    <DefaultLayout title={t('pinLoginDocument')} loading={user}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <AppealStepHeader step={1} title='Pin Login' nextStep='Select Punishment' />
+          <AppealStepHeader step={1} title={t('stepHeader.step1')} nextStep={t('stepHeader.selectPunishment')} />
           <PlayerLoginPinForm onSuccess={onSuccess} />
         </Panel>
       </PageContainer>

--- a/pages/appeal/punishment/[serverId]/ban/[id].js
+++ b/pages/appeal/punishment/[serverId]/ban/[id].js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../../../../components/DefaultLayout'
 import PageContainer from '../../../../../components/PageContainer'
 import ErrorLayout from '../../../../../components/ErrorLayout'
@@ -10,6 +11,7 @@ import AppealStepHeader from '../../../../../components/appeal/AppealStepHeader'
 import Button from '../../../../../components/Button'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const { hasServerPermission } = useUser({ redirectIfFound: false, redirectTo: '/' })
 
@@ -50,16 +52,16 @@ export default function Page () {
   if (errors) return <ErrorLayout errors={errors} />
 
   return (
-    <DefaultLayout title='Appeal Ban | Appeal' loading={loading}>
+    <DefaultLayout title={t('pages.appeal.appealBanDocument')} loading={loading}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <AppealStepHeader step={3} title='Appeal Ban' nextStep='Await Review' />
+          <AppealStepHeader step={3} title={t('pages.appeal.appealBan')} nextStep={t('pages.appeal.stepHeader.awaitReview')} />
           {!loading && !data?.playerBan && (
             <div>
-              <h2 className='text-center text-base font-semibold leading-relaxed pb-1'>Punishment not found</h2>
-              <p className='text-center text-sm font-normal leading-snug pb-4'>Head back to the previous page</p>
+              <h2 className='text-center text-base font-semibold leading-relaxed pb-1'>{t('pages.appeal.punishmentNotFound')}</h2>
+              <p className='text-center text-sm font-normal leading-snug pb-4'>{t('pages.appeal.headBack')}</p>
               <div className='flex gap-3'>
-                <Button onClick={() => router.back()}>Back</Button>
+                <Button onClick={() => router.back()}>{t('common.back')}</Button>
               </div>
             </div>
           )}

--- a/pages/appeal/punishment/[serverId]/mute/[id].js
+++ b/pages/appeal/punishment/[serverId]/mute/[id].js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../../../../components/DefaultLayout'
 import PageContainer from '../../../../../components/PageContainer'
 import ErrorLayout from '../../../../../components/ErrorLayout'
@@ -10,6 +11,7 @@ import AppealStepHeader from '../../../../../components/appeal/AppealStepHeader'
 import Button from '../../../../../components/Button'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const { hasServerPermission } = useUser({ redirectIfFound: false, redirectTo: '/' })
 
@@ -50,16 +52,16 @@ export default function Page () {
   if (errors) return <ErrorLayout errors={errors} />
 
   return (
-    <DefaultLayout title='Appeal Mute | Appeal' loading={loading}>
+    <DefaultLayout title={t('pages.appeal.appealMuteDocument')} loading={loading}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <AppealStepHeader step={3} title='Appeal Mute' nextStep='Await Review' />
+          <AppealStepHeader step={3} title={t('pages.appeal.appealMute')} nextStep={t('pages.appeal.stepHeader.awaitReview')} />
           {!loading && !data?.playerMute && (
             <div>
-              <h2 className='text-center text-base font-semibold leading-relaxed pb-1'>Punishment not found</h2>
-              <p className='text-center text-sm font-normal leading-snug pb-4'>Head back to the previous page</p>
+              <h2 className='text-center text-base font-semibold leading-relaxed pb-1'>{t('pages.appeal.punishmentNotFound')}</h2>
+              <p className='text-center text-sm font-normal leading-snug pb-4'>{t('pages.appeal.headBack')}</p>
               <div className='flex gap-3'>
-                <Button onClick={() => router.back()}>Back</Button>
+                <Button onClick={() => router.back()}>{t('common.back')}</Button>
               </div>
             </div>
           )}

--- a/pages/appeal/punishment/[serverId]/warning/[id].js
+++ b/pages/appeal/punishment/[serverId]/warning/[id].js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../../../../components/DefaultLayout'
 import PageContainer from '../../../../../components/PageContainer'
 import ErrorLayout from '../../../../../components/ErrorLayout'
@@ -10,6 +11,7 @@ import AppealStepHeader from '../../../../../components/appeal/AppealStepHeader'
 import Button from '../../../../../components/Button'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const { hasServerPermission } = useUser({ redirectIfFound: false, redirectTo: '/' })
 
@@ -50,16 +52,16 @@ export default function Page () {
   if (errors) return <ErrorLayout errors={errors} />
 
   return (
-    <DefaultLayout title='Appeal Warning | Appeal' loading={loading}>
+    <DefaultLayout title={t('pages.appeal.appealWarningDocument')} loading={loading}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <AppealStepHeader step={3} title='Appeal Warning' nextStep='Await Review' />
+          <AppealStepHeader step={3} title={t('pages.appeal.appealWarning')} nextStep={t('pages.appeal.stepHeader.awaitReview')} />
           {!loading && !data?.playerWarning && (
             <div>
-              <h2 className='text-center text-base font-semibold leading-relaxed pb-1'>Punishment not found</h2>
-              <p className='text-center text-sm font-normal leading-snug pb-4'>Head back to the previous page</p>
+              <h2 className='text-center text-base font-semibold leading-relaxed pb-1'>{t('pages.appeal.punishmentNotFound')}</h2>
+              <p className='text-center text-sm font-normal leading-snug pb-4'>{t('pages.appeal.headBack')}</p>
               <div className='flex gap-3'>
-                <Button onClick={() => router.back()}>Back</Button>
+                <Button onClick={() => router.back()}>{t('common.back')}</Button>
               </div>
             </div>
           )}

--- a/pages/appeal/punishment/index.js
+++ b/pages/appeal/punishment/index.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../../components/DefaultLayout'
 import PageContainer from '../../../components/PageContainer'
 import { useUser } from '../../../utils'
@@ -6,13 +7,14 @@ import AppealStepHeader from '../../../components/appeal/AppealStepHeader'
 import PunishmentPicker from '../../../components/appeal/PunishmentPicker'
 
 function Page () {
+  const t = useTranslations('pages.appeal')
   const { user } = useUser({ redirectIfFound: false, redirectTo: '/appeal' })
 
   return (
-    <DefaultLayout title='Select Punishment | Appeal' loading={!user}>
+    <DefaultLayout title={t('punishmentDocumentTitle')} loading={!user}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <AppealStepHeader step={2} title='Select Punishment' nextStep='Write Appeal' />
+          <AppealStepHeader step={2} title={t('stepHeader.selectPunishment')} nextStep={t('stepHeader.writeAppeal')} />
           <PunishmentPicker />
         </Panel>
       </PageContainer>

--- a/pages/appeals/[id].js
+++ b/pages/appeals/[id].js
@@ -1,15 +1,21 @@
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { format, fromUnixTime } from 'date-fns'
+import { useLocale, useTranslations } from 'next-intl'
 import DefaultLayout from '../../components/DefaultLayout'
 import ErrorLayout from '../../components/ErrorLayout'
 import PageContainer from '../../components/PageContainer'
 import PlayerAppealBadge from '../../components/appeals/PlayerAppealBadge'
 import PlayerAppealCommentList from '../../components/appeals/PlayerAppealCommentList'
 import { fromNow, useApi, useUser } from '../../utils'
+import { LOCALE_CONFIG, DEFAULT_LOCALE } from '../../utils/locale'
+import { useDateFnsLocale } from '../../utils/format-distance'
 import PlayerAppealSidebar from '../../components/appeals/PlayerAppealSidebar'
 
 export default function Page () {
+  const t = useTranslations()
+  const locale = useLocale()
+  const dateFnsLocale = useDateFnsLocale()
   const { user } = useUser()
   const router = useRouter()
   const { id } = router.query
@@ -78,16 +84,25 @@ export default function Page () {
   })
   const appeal = data?.appeal
 
-  if (loading) return <DefaultLayout title='Loading...' loading />
+  if (loading) return <DefaultLayout title={t('common.loading')} loading />
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const stateOptions = data.appealStates.map(state => ({ value: state.id, label: state.name }))
   const canComment = appeal.state.id < 3 && appeal.acl.comment
   const canUpdateState = appeal.acl.state
   const canAssign = appeal.acl.assign
+  const dateFormat = LOCALE_CONFIG[locale]?.dateFormat || LOCALE_CONFIG[DEFAULT_LOCALE].dateFormat
+  const formatDate = (timestamp) => {
+    try {
+      return format(fromUnixTime(timestamp), dateFormat, dateFnsLocale ? { locale: dateFnsLocale } : undefined)
+    } catch {
+      return format(fromUnixTime(timestamp), dateFormat)
+    }
+  }
+  const punishmentKind = appeal.punishmentExpires === 0 ? 'permanent' : 'temporary'
 
   return (
-    <DefaultLayout title={`#${id} | ${appeal.actor.name} | ${appeal.punishmentReason} | Appeal`}>
+    <DefaultLayout title={t('pages.appeals.documentTitle', { id, name: appeal.actor.name, reason: appeal.punishmentReason })}>
       <PageContainer>
         <div className='pb-6'>
           <h1
@@ -95,20 +110,19 @@ export default function Page () {
           >
             <span className='mr-3'>{appeal.punishmentReason}</span>
             <span className='block md:inline text-gray-400'>#{appeal.id}</span>
-            <span className='block md:inline text-gray-400'> {format(fromUnixTime(appeal.created), 'dd MMM yyyy')}</span>
+            <span className='block md:inline text-gray-400'> {formatDate(appeal.created)}</span>
           </h1>
           <p className='pb-4 border-b border-accent-400 text-gray-400'>
-            <Link href={`/player/${appeal.actor.id}`}>
-
-              {appeal.actor.name}
-
-            </Link> is appealing a{appeal.punishmentExpires === 0 ? ' permanent' : ' temporary'} <PlayerAppealBadge appeal={appeal} /> issued on {format(fromUnixTime(appeal.punishmentCreated), 'dd MMM yyyy')} by&nbsp;
-            <Link href={`/player/${appeal.punishmentActor.id}`}>
-
-              {appeal.punishmentActor.name}
-
-            </Link>
-            {appeal.punishmentExpires !== 0 && ` which expires ${fromNow(appeal.punishmentExpires)}`}
+            {t.rich('pages.appeals.appealingSentence', {
+              actorName: appeal.actor.name,
+              punisherName: appeal.punishmentActor.name,
+              kind: punishmentKind,
+              issuedDate: formatDate(appeal.punishmentCreated),
+              expiresTime: appeal.punishmentExpires === 0 ? '' : fromNow(appeal.punishmentExpires),
+              actor: (chunks) => <Link href={`/player/${appeal.actor.id}`}>{chunks}</Link>,
+              punisher: (chunks) => <Link href={`/player/${appeal.punishmentActor.id}`}>{chunks}</Link>,
+              badge: () => <PlayerAppealBadge appeal={appeal} />
+            })}
           </p>
         </div>
         <div className='grid grid-flow-row md:grid-flow-col grid-cols-12'>

--- a/pages/dashboard/appeals.js
+++ b/pages/dashboard/appeals.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import PlayerAppeals from '../../components/dashboard/PlayerAppeals'
 import DefaultLayout from '../../components/DefaultLayout'
 import Loader from '../../components/Loader'
@@ -6,15 +7,16 @@ import PageHeader from '../../components/PageHeader'
 import { useUser } from '../../utils'
 
 export default function Page () {
+  const t = useTranslations()
   const { user } = useUser({ redirectTo: '/login', redirectIfFound: false })
 
   if (!user) return <Loader />
 
   return (
-    <DefaultLayout title='Appeals | Dashboard'>
+    <DefaultLayout title={t('pages.dashboard.appealsDocumentTitle')}>
       <PageContainer>
-        <PageHeader title='Dashboard' />
-        <PlayerAppeals title='Appeals' showActor />
+        <PageHeader title={t('pages.dashboard.title')} />
+        <PlayerAppeals title={t('pages.dashboard.appeals')} showActor />
       </PageContainer>
     </DefaultLayout>
   )

--- a/pages/dashboard/index.js
+++ b/pages/dashboard/index.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import ActivePunishments from '../../components/dashboard/ActivePunishments'
 import PlayerAppeals from '../../components/dashboard/PlayerAppeals'
 import PlayerReports from '../../components/dashboard/PlayerReports'
@@ -9,25 +10,26 @@ import PlayerStatistics from '../../components/player/PlayerStatistics'
 import { useUser } from '../../utils'
 
 export default function Page () {
+  const t = useTranslations()
   const { user } = useUser({ redirectTo: '/login', redirectIfFound: false })
 
   if (!user) return <Loader />
 
   return (
-    <DefaultLayout title='Dashboard'>
+    <DefaultLayout title={t('pages.dashboard.documentTitle')}>
       <PageContainer>
-        <PageHeader title='Dashboard' />
+        <PageHeader title={t('pages.dashboard.title')} />
         <div className='space-y-10'>
           <PlayerStatistics id={user.id} />
           <div data-cy='dashboard-widget-active-punishments'>
-            <h2 className='text-lg font-bold pb-4 border-b border-accent-200 leading-none' data-cy='dashboard-widget-title'>Active Punishments</h2>
+            <h2 className='text-lg font-bold pb-4 border-b border-accent-200 leading-none' data-cy='dashboard-widget-title'>{t('pages.dashboard.activePunishments')}</h2>
             <ActivePunishments id={user.id} />
           </div>
           <div>
-            <PlayerAppeals id={user.id} title='Your appeals' />
+            <PlayerAppeals id={user.id} title={t('pages.dashboard.yourAppeals')} />
           </div>
           <div>
-            <PlayerReports id={user.id} title='Your reports' />
+            <PlayerReports id={user.id} title={t('pages.dashboard.yourReports')} />
           </div>
         </div>
       </PageContainer>

--- a/pages/dashboard/reports.js
+++ b/pages/dashboard/reports.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import PlayerReports from '../../components/dashboard/PlayerReports'
 import DefaultLayout from '../../components/DefaultLayout'
 import Loader from '../../components/Loader'
@@ -6,15 +7,16 @@ import PageHeader from '../../components/PageHeader'
 import { useUser } from '../../utils'
 
 export default function Page () {
+  const t = useTranslations()
   const { user } = useUser({ redirectTo: '/login', redirectIfFound: false })
 
   if (!user) return <Loader />
 
   return (
-    <DefaultLayout title='Reports | Dashboard'>
+    <DefaultLayout title={t('pages.dashboard.reportsDocumentTitle')}>
       <PageContainer>
-        <PageHeader title='Dashboard' />
-        <PlayerReports title='Reports' />
+        <PageHeader title={t('pages.dashboard.title')} />
+        <PlayerReports title={t('pages.dashboard.reports')} />
       </PageContainer>
     </DefaultLayout>
   )

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../components/DefaultLayout'
 import AppealPanel from '../components/home/AppealPanel'
 import SearchPanel from '../components/home/SearchPanel'
@@ -6,8 +7,10 @@ import StatisticsPanel from '../components/home/StatisticsPanel'
 import PageContainer from '../components/PageContainer'
 
 export default function Page () {
+  const t = useTranslations()
+
   return (
-    <DefaultLayout title='Welcome'>
+    <DefaultLayout title={t('pages.home.documentTitle')}>
       <PageContainer>
         <div className='flex flex-wrap -m-4'>
           <div className='p-4 lg:w-1/3'>

--- a/pages/notifications.js
+++ b/pages/notifications.js
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../components/DefaultLayout'
 import PageContainer from '../components/PageContainer'
 import PageHeader from '../components/PageHeader'
@@ -6,12 +7,13 @@ import NotificationList from '../components/notifications/NotificationList'
 import PushNotificationButton from '../components/notifications/PushNotificationButton'
 
 function Page () {
+  const t = useTranslations()
   const { user } = useUser({ redirectTo: '/login', redirectIfFound: false })
 
   return (
-    <DefaultLayout title='Notifications'>
+    <DefaultLayout title={t('pages.notifications.documentTitle')}>
       <PageContainer>
-        <PageHeader title='Notifications' containerClassName='!justify-between'>
+        <PageHeader title={t('pages.notifications.title')} containerClassName='!justify-between'>
           {typeof window !== 'undefined' && 'Notification' in window && user && <PushNotificationButton />}
         </PageHeader>
         <NotificationList />

--- a/pages/player/[id]/ban.js
+++ b/pages/player/[id]/ban.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../../components/DefaultLayout'
 import PageContainer from '../../../components/PageContainer'
 import PlayerBanForm from '../../../components/PlayerBanForm'
@@ -8,6 +9,7 @@ import { useApi, useUser } from '../../../utils'
 import Panel from '../../../components/Panel'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const { id } = router.query
   const { loading, data, errors } = useApi({
@@ -32,10 +34,10 @@ export default function Page () {
   }`
 
   return (
-    <DefaultLayout title={`Ban ${data?.player?.name}`} loading={loading}>
+    <DefaultLayout title={t('pages.player.actionTitles.ban', { name: data?.player?.name ?? '' })} loading={loading}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader title={`Ban ${data?.player?.name}`} />
+          <PageHeader title={t('pages.player.actionTitles.ban', { name: data?.player?.name ?? '' })} />
           <PlayerBanForm
             serverFilter={server => hasServerPermission('player.bans', 'create', server.id)}
             query={query}

--- a/pages/player/[id]/mute.js
+++ b/pages/player/[id]/mute.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../../components/DefaultLayout'
 import PageContainer from '../../../components/PageContainer'
 import PlayerMuteForm from '../../../components/PlayerMuteForm'
@@ -8,6 +9,7 @@ import { useApi, useUser } from '../../../utils'
 import Panel from '../../../components/Panel'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const { id } = router.query
   const { loading, data, errors } = useApi({
@@ -32,10 +34,10 @@ export default function Page () {
   }`
 
   return (
-    <DefaultLayout title={`Mute ${data?.player?.name}`} loading={loading}>
+    <DefaultLayout title={t('pages.player.actionTitles.mute', { name: data?.player?.name ?? '' })} loading={loading}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader title={`Mute ${data?.player?.name}`} subTitle='' />
+          <PageHeader title={t('pages.player.actionTitles.mute', { name: data?.player?.name ?? '' })} subTitle='' />
           <PlayerMuteForm
             serverFilter={server => hasServerPermission('player.mutes', 'create', server.id)}
             query={query}

--- a/pages/player/[id]/note.js
+++ b/pages/player/[id]/note.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../../components/DefaultLayout'
 import PageContainer from '../../../components/PageContainer'
 import PlayerNoteForm from '../../../components/PlayerNoteForm'
@@ -8,6 +9,7 @@ import { useApi, useUser } from '../../../utils'
 import Panel from '../../../components/Panel'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const { id } = router.query
   const { loading, data, errors } = useApi({
@@ -36,10 +38,10 @@ export default function Page () {
   }`
 
   return (
-    <DefaultLayout title={`Add note to ${data?.player?.name}`} loading={loading}>
+    <DefaultLayout title={t('pages.player.actionTitles.addNoteDocument', { name: data?.player?.name ?? '' })} loading={loading}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader title='Add note' subTitle={data?.player?.name} />
+          <PageHeader title={t('pages.player.actionTitles.addNoteHeader')} subTitle={data?.player?.name} />
           <PlayerNoteForm
             serverFilter={server => hasServerPermission('player.notes', 'create', server.id)}
             query={query}

--- a/pages/player/[id]/warn.js
+++ b/pages/player/[id]/warn.js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../../components/DefaultLayout'
 import PageContainer from '../../../components/PageContainer'
 import PlayerWarnForm from '../../../components/PlayerWarnForm'
@@ -8,6 +9,7 @@ import { useApi, useUser } from '../../../utils'
 import Panel from '../../../components/Panel'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const { id } = router.query
   const { loading, data, errors } = useApi({
@@ -36,10 +38,10 @@ export default function Page () {
   }`
 
   return (
-    <DefaultLayout title={`Warn ${data?.player?.name}`} loading={loading}>
+    <DefaultLayout title={t('pages.player.actionTitles.warn', { name: data?.player?.name ?? '' })} loading={loading}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader title={`Warn ${data?.player?.name}`} />
+          <PageHeader title={t('pages.player.actionTitles.warn', { name: data?.player?.name ?? '' })} />
           <PlayerWarnForm
             serverFilter={server => hasServerPermission('player.warnings', 'create', server.id)}
             query={query}

--- a/pages/player/ban/[id].js
+++ b/pages/player/ban/[id].js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../../components/DefaultLayout'
 import PageContainer from '../../../components/PageContainer'
 import PlayerBanForm from '../../../components/PlayerBanForm'
@@ -8,6 +9,7 @@ import { fromNow, useApi } from '../../../utils'
 import Panel from '../../../components/Panel'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const [serverId, id] = router.query.id?.split('-') || []
   const { loading, data, errors } = useApi({
@@ -41,10 +43,10 @@ export default function Page () {
   }`
 
   return (
-    <DefaultLayout title={`Edit ${data?.playerBan?.player?.name} ban`} loading={loading}>
+    <DefaultLayout title={t('pages.player.actionTitles.editBanDocument', { name: data?.playerBan?.player?.name ?? '' })} loading={loading}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader title='Edit ban' subTitle={fromNow(data?.playerBan?.created || 0)} />
+          <PageHeader title={t('pages.player.actionTitles.editBan')} subTitle={fromNow(data?.playerBan?.created || 0)} />
           <PlayerBanForm
             defaults={data?.playerBan}
             query={query}

--- a/pages/player/mute/[id].js
+++ b/pages/player/mute/[id].js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../../components/DefaultLayout'
 import PageContainer from '../../../components/PageContainer'
 import PlayerMuteForm from '../../../components/PlayerMuteForm'
@@ -8,6 +9,7 @@ import { fromNow, useApi } from '../../../utils'
 import Panel from '../../../components/Panel'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const [serverId, id] = router.query.id?.split('-') || []
   const { loading, data, errors } = useApi({
@@ -42,10 +44,10 @@ export default function Page () {
   }`
 
   return (
-    <DefaultLayout title={`Edit ${data?.playerMute?.player?.name} mute`} loading={loading}>
+    <DefaultLayout title={t('pages.player.actionTitles.editMuteDocument', { name: data?.playerMute?.player?.name ?? '' })} loading={loading}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader title='Edit mute' subTitle={fromNow(data?.playerMute?.created || 0)} />
+          <PageHeader title={t('pages.player.actionTitles.editMute')} subTitle={fromNow(data?.playerMute?.created || 0)} />
           <PlayerMuteForm
             defaults={data?.playerMute}
             query={query}

--- a/pages/player/note/[id].js
+++ b/pages/player/note/[id].js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../../components/DefaultLayout'
 import PageContainer from '../../../components/PageContainer'
 import PlayerNoteForm from '../../../components/PlayerNoteForm'
@@ -8,6 +9,7 @@ import { fromNow, useApi } from '../../../utils'
 import Panel from '../../../components/Panel'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const [serverId, id] = router.query.id?.split('-') || []
   const { loading, data, errors } = useApi({
@@ -40,10 +42,10 @@ export default function Page () {
   }`
 
   return (
-    <DefaultLayout title={`Edit ${data?.playerNote?.player?.name} note`} loading={loading}>
+    <DefaultLayout title={t('pages.player.actionTitles.editNoteDocument', { name: data?.playerNote?.player?.name ?? '' })} loading={loading}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader title='Edit note' subTitle={fromNow(data?.playerNote?.created || 0)} />
+          <PageHeader title={t('pages.player.actionTitles.editNote')} subTitle={fromNow(data?.playerNote?.created || 0)} />
           <PlayerNoteForm
             defaults={data?.playerNote}
             query={query}

--- a/pages/player/warning/[id].js
+++ b/pages/player/warning/[id].js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useTranslations } from 'next-intl'
 import DefaultLayout from '../../../components/DefaultLayout'
 import PageContainer from '../../../components/PageContainer'
 import PlayerWarnForm from '../../../components/PlayerWarnForm'
@@ -8,6 +9,7 @@ import { fromNow, useApi } from '../../../utils'
 import Panel from '../../../components/Panel'
 
 export default function Page () {
+  const t = useTranslations()
   const router = useRouter()
   const [serverId, id] = router.query.id?.split('-') || []
   const { loading, data, errors } = useApi({
@@ -42,10 +44,10 @@ export default function Page () {
   }`
 
   return (
-    <DefaultLayout title={`Edit ${data?.playerWarning?.player?.name} warning`} loading={loading}>
+    <DefaultLayout title={t('pages.player.actionTitles.editWarningDocument', { name: data?.playerWarning?.player?.name ?? '' })} loading={loading}>
       <PageContainer>
         <Panel className='mx-auto w-full max-w-md'>
-          <PageHeader title='Edit warning' subTitle={fromNow(data?.playerWarning?.created || 0)} />
+          <PageHeader title={t('pages.player.actionTitles.editWarning')} subTitle={fromNow(data?.playerWarning?.created || 0)} />
           <PlayerWarnForm
             defaults={data?.playerWarning}
             query={query}

--- a/pages/reports/[serverId]/[id].js
+++ b/pages/reports/[serverId]/[id].js
@@ -1,7 +1,10 @@
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { format, fromUnixTime } from 'date-fns'
+import { useLocale, useTranslations } from 'next-intl'
 import { useApi, useUser } from '../../../utils'
+import { LOCALE_CONFIG, DEFAULT_LOCALE } from '../../../utils/locale'
+import { useDateFnsLocale } from '../../../utils/format-distance'
 import DefaultLayout from '../../../components/DefaultLayout'
 import ErrorLayout from '../../../components/ErrorLayout'
 import PageContainer from '../../../components/PageContainer'
@@ -10,6 +13,9 @@ import PlayerReportServerLogs from '../../../components/reports/PlayerReportServ
 import PlayerReportSidebar from '../../../components/reports/PlayerReportSidebar'
 
 export default function Page () {
+  const t = useTranslations()
+  const locale = useLocale()
+  const dateFnsLocale = useDateFnsLocale()
   const { user } = useUser()
   const router = useRouter()
   const { id, serverId } = router.query
@@ -98,16 +104,24 @@ export default function Page () {
 
   const report = data?.report
 
-  if (loading) return <DefaultLayout title='Loading...' loading />
+  if (loading) return <DefaultLayout title={t('common.loading')} loading />
   if (errors || !data) return <ErrorLayout errors={errors} />
 
   const stateOptions = data.reportStates.map(state => ({ value: state.id, label: state.name }))
   const canComment = report.state.id < 3 && report.acl.comment
   const canUpdateState = report.acl.state
   const canAssign = report.acl.assign
+  const dateFormat = LOCALE_CONFIG[locale]?.dateFormat || LOCALE_CONFIG[DEFAULT_LOCALE].dateFormat
+  const formattedDate = (() => {
+    try {
+      return format(fromUnixTime(report.created), dateFormat, dateFnsLocale ? { locale: dateFnsLocale } : undefined)
+    } catch {
+      return format(fromUnixTime(report.created), dateFormat)
+    }
+  })()
 
   return (
-    <DefaultLayout title={`#${id} | ${report.actor.name} | ${report.reason} | Report`}>
+    <DefaultLayout title={t('pages.report.documentTitle', { id, name: report.actor.name, reason: report.reason })}>
       <PageContainer>
         <div className='pb-6'>
           <h1
@@ -117,17 +131,13 @@ export default function Page () {
             <span className='block md:inline text-gray-400'>#{report.id}</span>
           </h1>
           <p className='pb-4 border-b border-accent-400 text-gray-400'>
-            <Link href={`/player/${report.actor.id}`}>
-
-              {report.actor.name}
-
-            </Link> reported&nbsp;
-            <Link href={`/player/${report.player.id}`}>
-
-              {report.player.name}
-
-            </Link>
-            &nbsp;on {format(fromUnixTime(report.created), 'dd MMM yyyy')}
+            {t.rich('pages.report.reportedSentence', {
+              actorName: report.actor.name,
+              playerName: report.player.name,
+              date: formattedDate,
+              actor: (chunks) => <Link href={`/player/${report.actor.id}`}>{chunks}</Link>,
+              player: (chunks) => <Link href={`/player/${report.player.id}`}>{chunks}</Link>
+            })}
           </p>
         </div>
         <div className='grid grid-flow-row md:grid-flow-col grid-cols-12'>

--- a/server/graphql/resolvers/queries/admin-navigation.js
+++ b/server/graphql/resolvers/queries/admin-navigation.js
@@ -5,11 +5,11 @@ module.exports = async function adminNavigation (obj, info, { state }) {
   const { documentsCount } = await state.dbPool('bm_web_documents').count({ documentsCount: '*' }).first()
 
   const left = [
-    { name: 'Documents', label: documentsCount, href: '/admin/documents' },
-    { name: 'Roles', label: rolesCount, href: '/admin/roles' },
-    { name: 'Servers', label: state.serversPool.size, href: '/admin/servers' },
-    { name: 'Notification Rules', label: notificationRulesCount, href: '/admin/notification-rules' },
-    { name: 'Webhooks', label: webHooksCount, href: '/admin/webhooks' }
+    { key: 'documents', name: 'Documents', label: documentsCount, href: '/admin/documents' },
+    { key: 'roles', name: 'Roles', label: rolesCount, href: '/admin/roles' },
+    { key: 'servers', name: 'Servers', label: state.serversPool.size, href: '/admin/servers' },
+    { key: 'notificationRules', name: 'Notification Rules', label: notificationRulesCount, href: '/admin/notification-rules' },
+    { key: 'webhooks', name: 'Webhooks', label: webHooksCount, href: '/admin/webhooks' }
   ]
 
   left.sort((a, b) => a.name.localeCompare(b.name))

--- a/server/graphql/types.js
+++ b/server/graphql/types.js
@@ -414,6 +414,7 @@ type MenuItem {
 type AdminMenuItem {
   id: ID!
   name: String!
+  key: String
   href: String
   label: Int
 }

--- a/utils/locale.js
+++ b/utils/locale.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useUser } from './index'
 import {
   SUPPORTED_LOCALES,
@@ -59,32 +59,6 @@ const negotiateFromNavigator = () => {
   return null
 }
 
-export const useResolvedLocale = () => {
-  const { user } = useUser()
-  const [locale, setLocale] = useState(DEFAULT_LOCALE)
-  const [ready, setReady] = useState(false)
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-
-    const cookieLocale = readClientCookie(LOCALE_COOKIE)
-
-    if (isSupportedLocale(user?.locale)) {
-      setLocale(user.locale)
-    } else if (isSupportedLocale(cookieLocale)) {
-      setLocale(cookieLocale)
-    } else {
-      const navLocale = negotiateFromNavigator()
-
-      if (navLocale) setLocale(navLocale)
-    }
-
-    setReady(true)
-  }, [user?.locale])
-
-  return { locale, ready }
-}
-
 export const getCookiePath = () => {
   const basePath = process.env.BASE_PATH || ''
 
@@ -99,3 +73,72 @@ export const writeLocaleCookie = (locale) => {
 
   document.cookie = `${LOCALE_COOKIE}=${encodeURIComponent(locale)}; Path=${path}; Max-Age=${maxAge}; SameSite=Lax`
 }
+
+const LocaleContext = createContext({
+  locale: DEFAULT_LOCALE,
+  ready: false,
+  setLocale: () => {}
+})
+
+export const LocaleProvider = ({ children }) => {
+  const { user } = useUser()
+  const [locale, setLocaleState] = useState(DEFAULT_LOCALE)
+  const [ready, setReady] = useState(false)
+  const [explicit, setExplicit] = useState(false)
+  const previousUserId = useRef(null)
+
+  useEffect(() => {
+    if (previousUserId.current !== null && previousUserId.current !== (user?.id ?? null)) {
+      setExplicit(false)
+    }
+
+    previousUserId.current = user?.id ?? null
+  }, [user?.id])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    if (isSupportedLocale(user?.locale) && !explicit) {
+      setLocaleState(user.locale)
+      setReady(true)
+
+      return
+    }
+
+    if (explicit) {
+      setReady(true)
+
+      return
+    }
+
+    const cookieLocale = readClientCookie(LOCALE_COOKIE)
+
+    if (isSupportedLocale(cookieLocale)) {
+      setLocaleState(cookieLocale)
+    } else {
+      const navLocale = negotiateFromNavigator()
+
+      if (navLocale) setLocaleState(navLocale)
+    }
+
+    setReady(true)
+  }, [user?.locale, explicit])
+
+  const setLocale = useCallback((next) => {
+    if (!isSupportedLocale(next)) return
+
+    writeLocaleCookie(next)
+    setExplicit(true)
+    setLocaleState(next)
+  }, [])
+
+  const value = useMemo(() => ({ locale, ready, setLocale }), [locale, ready, setLocale])
+
+  return (
+    <LocaleContext.Provider value={value}>
+      {children}
+    </LocaleContext.Provider>
+  )
+}
+
+export const useResolvedLocale = () => useContext(LocaleContext)


### PR DESCRIPTION
## Summary

Follow-up to the initial i18n landing in #1765. Closes the remaining
translation gaps reported on the merged feature and addresses the PR
review findings.

### Locale infrastructure
- Centralized `LocaleContext` / `LocaleProvider` so the language dropdown
  applies immediately without a page refresh.
- Memoized the provider's context value (`useMemo` + `useCallback`) and
  reset the explicit-locale flag on `user.id` change so cookie/navigator
  fallbacks are no longer permanently shadowed.
- `useDateFnsLocale` is now wired through history, command, server-stat,
  and report components for locale-aware date formatting.

### Translation completeness
- Translated every remaining English string surfaced in bug reports:
  homepage, dashboard, dashboard/appeals, player pages, notifications,
  account/email, account/password, and the entire admin panel
  (servers, roles, webhooks, notification rules, documents, ...).
- Added German messages for ~470 new keys; `en.json` and `de.json` are at
  full key parity (562 keys each).

### Translatability quality
- Replaced the sentence-splitting anti-pattern with single rich-text ICU
  keys that embed React components (`<actor>`, `<punisher>`, `<player>`,
  `<badge>`, `<path>`, `<docs>`) for the report header, appeal description,
  comment timestamps, punishment update messages, and push-notification
  setup steps.
- ICU `select` for permanent vs. temporary appeal grammar; ICU `plural`
  for player counts (active/past bans, mutes, warnings, notes, kicks,
  report records).
- Collapsed concatenated page titles for `account/email`, `account/password`,
  and `admin/servers/[id]` into single parameterized keys.
- Standardized on `common.permanent` (dropped duplicate
  `pages.punishment.permanent`) and renamed `actions.warn` -> `actions.warning`
  to match the GraphQL type.

### Bug fixes
- **Critical**: Fixed `t.rich` rendering in `PushNotificationButton` by
  switching the message to rich-text tag syntax and a `chunks`-based
  render function instead of a placeholder (was returning `null` for the
  embedded `<pre>`).
- Dropped the default-arg `t()` call in `CommentWithUpload` so `t()` is
  only invoked when no `placeholder` prop is supplied.
- Restored unrelated comments accidentally removed from `ServerForm`.

### Backend
- `adminNavigation` resolver now localizes nav labels via the user's
  resolved locale; `User` GraphQL type exposes `locale` for client-side
  reconciliation.

## Test plan
- [x] `npm run lint` clean on modified files (only pre-existing SonarQube
      warnings remain).
- [x] `messages/en.json` and `messages/de.json` parse cleanly with full
      key parity (562 / 562).
- [x] ICU + rich-text parsing test for every refactored key (plurals,
      `select`, embedded React components) produces the expected output
      in both `en` and `de`.
- [x] `npm run build` completes successfully.
- [x] Backend tests pass against docker-compose MySQL:
      `setLocale.mutation.test.js` (4/4) and `adminNavigation.query.test.js` (1/1).
- [ ] Manual smoke test of the language dropdown: switching to Deutsch
      updates the UI immediately (no refresh required).
- [ ] Manual smoke test of homepage, dashboard, player, notifications,
      account, and admin pages in both `en` and `de`.