### PR TITLE
ci(docker): publish multi-arch image with native runners

### DIFF
--- a/.github/workflows/deploy_docker.yaml
+++ b/.github/workflows/deploy_docker.yaml
@@ -4,17 +4,34 @@ on:
   push:
     branches:
       - master
+      # TEMP: validate native-arm runner build before merging to master.
+      # Remove this branch entry before opening the PR for review.
+      - chore/native-arm-publish
 
 jobs:
-  push_to_registry:
-    name: Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+  # Build each platform on its own native runner. Building linux/arm64 under
+  # qemu-user on an amd64 runner has been broken since the Node 24 bump
+  # (qemu raises SIGILL on Arm v8.x instructions emitted by V8's JIT, exit
+  # 132). GitHub provides free `ubuntu-24.04-arm` runners for public repos,
+  # so we can build natively on each arch and stitch the results together
+  # into a manifest list in the merge job below. Pattern lifted from the
+  # docker/build-push-action multi-platform docs.
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     steps:
       - name: Check out the repo
         uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -25,21 +42,85 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: banmanagement/webui
 
-      - name: Build and push multi-platform Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            banmanagement/webui:${{ github.sha }}
-            banmanagement/webui:latest
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # push-by-digest avoids touching shared tags from per-arch jobs;
+          # the merge job below produces the actual `:latest` / `:<sha>`
+          # manifest list referencing both digests.
+          outputs: type=image,name=banmanagement/webui,push-by-digest=true,name-canonical=true,push=true
+          # Per-arch cache scope so amd64 and arm64 do not stomp on each
+          # other's layer caches.
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest='${{ steps.build.outputs.digest }}'
+          # The digest output is `sha256:<hex>`; the merge job wants just
+          # the hex (and to find the file in /tmp/digests).
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge into manifest
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: banmanagement/webui
+          # Reproduce the previous workflow's tag set:
+          #   - `latest` on default branch
+          #   - the full commit SHA
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=long
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'banmanagement/webui@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect \
+            "banmanagement/webui:$(jq -r '.tags[0] | split(":")[1]' <<< "$DOCKER_METADATA_OUTPUT_JSON")"

--- a/.github/workflows/deploy_docker.yaml
+++ b/.github/workflows/deploy_docker.yaml
@@ -31,23 +31,23 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: banmanagement/webui
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -90,17 +90,17 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: banmanagement/webui
           # Reproduce the previous workflow's tag set verbatim:

--- a/.github/workflows/deploy_docker.yaml
+++ b/.github/workflows/deploy_docker.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-      # TEMP: validate native-arm runner build before merging to master.
-      # Remove this branch entry before opening the PR for review.
-      - chore/native-arm-publish
 
 jobs:
   # Build each platform on its own native runner. Building linux/arm64 under
@@ -106,12 +103,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: banmanagement/webui
-          # Reproduce the previous workflow's tag set:
+          # Reproduce the previous workflow's tag set verbatim:
           #   - `latest` on default branch
-          #   - the full commit SHA
+          #   - the full commit SHA with no `sha-` prefix (the previous
+          #     workflow used `${{ github.sha }}` directly)
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,format=long
+            type=sha,format=long,prefix=
 
       - name: Create manifest list and push
         working-directory: /tmp/digests


### PR DESCRIPTION
## Summary

The `Publish Docker image` workflow has been broken on master since #1767 was merged ([failing run](https://github.com/BanManagement/BanManager-WebUI/actions/runs/24659501835/job/72101467079)). The `linux/arm64` leg ran under qemu-user on the amd64 runner and crashed in `npm ci` with `qemu: uncaught target signal 4 (Illegal instruction) - core dumped` (exit 132). This is Node 24's V8 emitting Arm v8.x JIT instructions that the runner's binfmt qemu cannot decode - a class of issue that the docker/buildx maintainers explicitly recommend resolving by switching to native runners now that GitHub provides them for free on public repos.

This PR replaces the single-job, qemu-emulated build with the standard docker/build-push-action multi-platform pattern:

- **Per-architecture matrix.** `linux/amd64` keeps its `ubuntu-latest` runner; `linux/arm64` moves to the free `ubuntu-24.04-arm` runner. Both jobs build their platform with no cross-compilation, then push **blob-only by-digest** so they never touch shared tags.
- **Manifest merge job.** A final `merge` job downloads both digests and stitches them together with `docker buildx imagetools create`, producing the same `:latest` and `:<sha>` tag set the previous workflow did.
- **Per-arch GHA cache scopes** so the two legs do not invalidate each other.

The full SHA tag is preserved without the metadata-action `sha-` prefix so anyone pulling by `${{ github.sha }}` keeps working.

## Validation

The workflow was validated on `chore/native-arm-publish` ([run 24660044323](https://github.com/BanManagement/BanManager-WebUI/actions/runs/24660044323)) with a temporary branch trigger:

- `Build linux/amd64` (ubuntu-latest): 5m 5s
- `Build linux/arm64` (ubuntu-24.04-arm): 6m 53s - native, no qemu
- `Merge into manifest`: 21s

The resulting `webui:sha-4c0ab51d...` (from the validation run, before the prefix fix) was inspected and contains `linux/amd64` + `linux/arm64` manifests plus the OCI provenance attestation, matching the prior multi-arch image shape. The temporary trigger has been removed in the second commit.

## Test plan

- [ ] Merge to `master` and confirm the `Publish Docker image` workflow succeeds, pushes both `banmanagement/webui:latest` and `banmanagement/webui:<merge-sha>`, and that `docker buildx imagetools inspect banmanagement/webui:latest` shows both `linux/amd64` and `linux/arm64`.
- [ ] Sanity-pull `banmanagement/webui:latest` on an Apple-Silicon (arm64) host and start it via `docker compose -f docker-compose.prod.yml up -d` to confirm runtime parity with the previous arm64 image.