### PR TITLE
fix: critical setup endpoints (/api/setup/database, ... in setup.js

### DIFF
--- a/server/routes/setup.js
+++ b/server/routes/setup.js
@@ -117,8 +117,15 @@ const buildRouter = ({ basePath, dbPool, allowAfterComplete = false } = {}) => {
   router.use(async (ctx, next) => {
     const rel = relativePath(ctx)
     if (!rel.startsWith('/api/setup')) return next()
-    if (!process.env.SETUP_TOKEN) return next()
     if (rel === '/api/setup/token' || rel === '/api/setup/preflight' || rel === '/api/setup/state') return next()
+    if (!process.env.SETUP_TOKEN) {
+      if (!isLoopback(ctx.request.ip)) {
+        ctx.status = 403
+        ctx.body = { error: 'Setup endpoints are only accessible from localhost when SETUP_TOKEN is not configured.' }
+        return
+      }
+      return next()
+    }
     const provided = (ctx.request.body && ctx.request.body.token) || ctx.get('X-Setup-Token')
     if (provided && timingSafeStringEqual(provided, process.env.SETUP_TOKEN)) return next()
     ctx.status = 401


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `server/routes/setup.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `server/routes/setup.js:162` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

**Description**: Critical setup endpoints (/api/setup/database, /api/setup/server, /api/setup/finalize, /api/setup/admin/preflight) are protected only by an optional SETUP_TOKEN environment variable. If SETUP_TOKEN is not set (default case), these endpoints are completely unauthenticated, allowing any attacker with network access to reconfigure the application.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This route handler appears to be publicly accessible. This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `server/routes/setup.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
